### PR TITLE
Update information on how to set up a test plan schedule

### DIFF
--- a/best-practices/running-tests.mdx
+++ b/best-practices/running-tests.mdx
@@ -23,7 +23,22 @@ For a great example, check out our [GitHub Actions documentation](/configuration
 
 If you want your tests to run at a specific time, such as on a recurring weekly schedule (cron-style), we offer that functionality as well.
 
-1. Go to [Results](https://app.qa.tech/dashboard/current-project/results) and press the **Schedule** button.
-2. Follow the instructions provided to set up the schedule.
+<Steps>
+  <Step title="Navigate to Test Plans">
+    Go to [Test Plans](https://app.qa.tech/dashboard/current-project/test-plans)
+    in your project dashboard.
+  </Step>
+  <Step title="Select or Create a Test Plan">
+    Click on an existing test plan that you want to schedule, or create a new
+    one if needed.
+  </Step>
+  <Step title="Manage Schedules">
+    Click on **Manage Schedules** within the test plan.
+  </Step>
+  <Step title="Add Schedule">
+    Add your cron schedule expression and a description, then click **Add
+    Schedule**.
+  </Step>
+</Steps>
 
 If you're unsure how to write the cron format, you can use a tool like [crontab.guru](https://crontab.guru/) or reach out to us, and we'll be happy to help you get set up.

--- a/core-concepts/test-plans.mdx
+++ b/core-concepts/test-plans.mdx
@@ -1,7 +1,7 @@
 ---
 title: Test plans
 description: Test Plans allow you to organize and manage groups of test cases that can be executed together as a single unit.
-icon: 'clipboard-list'
+icon: "clipboard-list"
 ---
 
 ## Overview
@@ -53,9 +53,22 @@ Test Plans can be triggered programmatically through the API. For detailed infor
 
 You can configure Test Plans to run automatically at specific times or intervals:
 
-1. Navigate to the Results page
-2. Click the "Schedule" button
-3. Configure cron for the schedule and select Test plan
+<Steps>
+  <Step title="Navigate to Test Plans">
+    Go to [Test Plans](https://app.qa.tech/dashboard/current-project/test-plans)
+    in your project dashboard.
+  </Step>
+  <Step title="Select Test Plan">
+    Click on the test plan you want to schedule.
+  </Step>
+  <Step title="Manage Schedules">
+    Click on **Manage Schedules** within the test plan.
+  </Step>
+  <Step title="Add Schedule">
+    Add your cron schedule expression and a description, then click **Add
+    Schedule**.
+  </Step>
+</Steps>
 
 ### UI Execution
 


### PR DESCRIPTION
This PR updates instruction on how to set up a test plan. The old way of doing it through Results has been removed. All scheduling now happens on a Test plan specifically.