### PR TITLE
docs: add HTTP Basic Auth explanation to configs

### DIFF
--- a/core-concepts/configs.mdx
+++ b/core-concepts/configs.mdx
@@ -53,6 +53,23 @@ QA.tech automatically provides several configs for common testing needs:
 
    - For standard authentication
    - Fields: Username (can be email) and password
+   - Optional "Use for Basic Auth" checkbox for HTTP Basic Authentication
+
+   <Accordion title="When to enable Basic Auth">
+     The "Use for Basic Auth" checkbox is for **HTTP Basic Authentication**, which is different from regular login forms.
+     
+     **Enable this when your tests need to access:**
+     - Staging or testing environments protected with browser authentication popups
+     - URLs that trigger browser dialogs asking for username/password
+     - Corporate proxies or internal tools requiring basic authentication
+     - Password-protected development environments
+     
+     When enabled, QA.tech automatically supplies these credentials to the browser whenever it encounters an HTTP Basic Auth challenge, so your tests can proceed without manual intervention.
+     
+     <Note>
+       **Important:** This is for the HTTP Basic Authentication protocol (RFC 7617), not for testing login forms on your website. For regular login forms, create a Username + Password config and leave "Use for Basic Auth" disabled.
+     </Note>
+   </Accordion>
 
 2. **Username + Password with 2FA**
 

--- a/docs-update-plan.md
+++ b/docs-update-plan.md
@@ -1,42 +1,60 @@
 # Documentation Tasklist for QA.tech
 
 **Created:** September 30, 2025  
-**Last Updated:** October 1, 2025  
+**Last Updated:** October 2, 2025  
 **Purpose:** Active tasklist and findings tracker for qatech-docs improvements
 
-## 🎯 Active Tasks
+## 🎯 Active Tasks - Prioritized & Verified
 
-### Priority 1: API Reference - CHAT Trigger Type ⚠️ **PENDING**
+### 🔴 CRITICAL PRIORITY (Customer-Facing, Missing Docs)
 
-- **File:** `/api-reference/start-run.json`
+#### 1. GitHub App Integration (Separate from GitHub Actions) ⚠️
+
+- **Target File:** `/integrations/github-app.mdx` (new file)
+- **Why Critical:** Distinct customer-facing integration separate from GitHub Actions
+- **What's Missing:** Complete integration guide for PR-based testing
+- **Key Points:**
+  - Distinct from GitHub Actions workflow integration
+  - Auto-runs exploratory + regression tests on PR creation/updates
+  - Screenshot available: `/assets/images/integrations/screenshot-review.jpg`
+  - Different setup flow than GitHub Actions (OAuth App vs Actions workflow)
+- **Code Reference:** `apps/saas/src/app/dashboard/p/[project]/settings/integrations/[integrationId]/components/GitHubAppIntegrationSettings.tsx`
+- **Action:** Create new integration guide; explain OAuth setup, PR triggers, review flow, permissions
+- **Status:** ⚠️ **PENDING**
+
+#### 2. Prometheus Metrics Integration ⚠️
+
+- **Target File:** `/integrations/prometheus.mdx` (new file)
+- **Why Critical:** New customer-facing integration with UI setup page
+- **What's Missing:** Complete integration guide with Prometheus scrape configuration
+- **Key Points:**
+  - Prometheus-compatible scrape endpoint for monitoring
+  - Metrics: runs (total/passed/failed/skipped), tests, user impact, deployments
+  - 30s scrape interval recommended
+  - Uses same API token as other integrations
+  - Includes prometheus.yml config example in UI
+- **Code Reference:** `apps/saas/src/app/dashboard/p/[project]/settings/integrations/[integrationId]/components/MetricsIntegrationSettings.tsx`
+- **Action:** Create integration guide with setup, config examples, available metrics reference, Grafana dashboard examples
+- **Cross-reference:** GET `/api/projects/{id}/metrics` endpoint (see API section)
+- **Status:** ⚠️ **PENDING**
+
+#### 3. API Reference - CHAT Trigger Type ⚠️
+
+- **Target File:** `/api-reference/start-run.json`
+- **Why Critical:** Missing trigger type in public API docs
 - **Issue:** Trigger enum missing CHAT type
-- **Fix:** Update enum to `["MANUAL", "API", "GITHUB", "SCHEDULE", "CHAT"]` + description + example
-- **Status:** ⏳ Needs to be done
+- **Fix:** Update enum to `["MANUAL", "API", "GITHUB", "SCHEDULE", "CHAT"]`
+- **Action:** Add CHAT description and example showing chat-initiated runs
+- **Status:** ⚠️ **PENDING**
 
-### Priority 2: Test Status Documentation (Optional)
+### 🟡 HIGH PRIORITY (Customer-Facing APIs)
 
-- **File:** `/core-concepts/tests-and-results.mdx`
-- **Issue:** Draft vs Active status not explicitly documented
-- **Status:** ⏳ Low priority - check UI tooltips first
+#### 4. POST `/api/projects/{id}/test-cases` - Test Case Creation API
 
----
-
-## ✅ Completed Tasks
-
-- **Oct 1, 2025:** Parallel Execution Documentation - Added "Performance & Parallel Execution" section to `/core-concepts/test-plans.mdx` explaining automatic parallelization (up to ~100 concurrent agents), dependency-aware scheduling, and auto-scaling. Added cross-reference note in `/best-practices/running-tests.mdx`.
-- **Oct 1, 2025:** IP Whitelisting CAPTCHA Clarification - Added service-agnostic section to `/configuration/ip-access-control.mdx` explaining NAT IPs work for reCAPTCHA, hCaptcha, AWS WAF, etc.
-
----
-
-## 📊 Audit Findings (Sept 30, 2025)
-
-### API Endpoints - Missing Documentation
-
-#### POST `/api/projects/{id}/test-cases` - HIGH PRIORITY
-
-**Purpose:** Programmatically create test cases via API  
-**Auth:** Bearer token (project.apiToken)  
-**Request Schema:**
+- **Target File:** `/api-reference/test-case-creation.mdx`
+- **Why High:** Core API for programmatic test case creation
+- **Current Status:** File exists but check if complete
+- **Request Schema:**
 
 ```typescript
 {
@@ -51,123 +69,267 @@
 }
 ```
 
-**Response:** `{ success: true, testCase: { id, name, url } }`  
-**Reference:** `apps/saas/src/app/api/projects/[projectUuid]/test-cases/README.md`
+- **Response:** `{ success: true, testCase: { id, name, url } }`
+- **Code Reference:** `apps/saas/src/app/api/projects/[projectUuid]/test-cases/README.md`
+- **Action:** Verify existing doc is complete; add dependency examples
+- **Status:** ⏳ Verify & update if needed
 
-#### GET `/api/projects/{id}/runs/{shortId}` - HIGH PRIORITY
+#### 5. GET `/api/projects/{id}/runs/{shortId}` - Run Status API
 
-**Purpose:** Get test run status and result (CI/CD polling)  
-**Auth:** Bearer token (project.apiToken)  
-**Response:** `{ id: string, short_id: string, status: string, result: string }`
+- **Target File:** `/api-reference/get-run-status.mdx` (new)
+- **Why High:** Critical for CI/CD polling and status monitoring
+- **Purpose:** Get test run status and result
+- **Auth:** Bearer token (project.apiToken)
+- **Response:** `{ id: string, short_id: string, status: string, result: string }`
+- **Action:** Create endpoint reference with polling examples
+- **Status:** ⏳ Needs to be done
 
-#### GET `/api/projects/{id}/metrics` - MEDIUM PRIORITY
+#### 6. GET `/api/projects/{id}/metrics` - Metrics API Endpoint
 
-**Purpose:** Retrieve comprehensive project test metrics  
-**Auth:** Bearer token (project.apiToken)  
-**Response:** `{ project_id, date_range: { from, to }, runs: { total, passed, failed, ... }, tests: { total, ... }, time_saved_minutes, ... }`  
-**Reference:** `apps/saas/src/app/api/projects/[projectUuid]/metrics/README.md`
+- **Target File:** Update `/api-reference/introduction.mdx` or create `/api-reference/metrics.mdx`
+- **Why High:** Supports Prometheus integration (Item #2)
+- **Purpose:** Retrieve comprehensive project test metrics
+- **Auth:** Bearer token (project.apiToken)
+- **Response Schema:**
 
-#### GET `/api/projects/{id}/badge.svg` - MEDIUM PRIORITY
+```typescript
+{
+  project_id: string,
+  date_range: { from: string, to: string },
+  runs: { total, passed, failed, skipped, ... },
+  tests: { total, ... },
+  time_saved_minutes: number,
+  ...
+}
+```
 
-**Purpose:** Generate status badge for embedding  
-**Auth:** Token via query param `?token={uuid}`  
-**Query Params:** `token` (required), `label?`, `style?` ('standard'|'flat'|'compact'), `showDate?`, `historyCount?`, `example?`  
-**Response:** SVG image
+- **Code Reference:** `apps/saas/src/app/api/projects/[projectUuid]/metrics/README.md`
+- **Action:** Create API reference with response schema, examples
+- **Status:** ⏳ Needs to be done
 
-#### POST `/api/projects/{id}/applications/{appId}/environments` - LOW PRIORITY
+### 🟢 MEDIUM PRIORITY (UX Improvements & Doc Updates)
 
-**Purpose:** Create new environment for application
-**Auth:** Bearer token  
-**Request:** `{ name: string (1-100 chars), url: string (valid URL), isPreview?: boolean }`
+#### 7. Device Presets - Accessibility Features (UPDATE EXISTING) ⚠️
 
-#### GET `/api/outbound-ips` - LOW PRIORITY
+- **Target File:** `/test-features/device-presets.mdx` (UPDATE)
+- **Why Medium:** Missing documentation for accessibility emulation features
+- **Current Status:** ✓ Doc exists but INCOMPLETE
+- **What's Missing:** Three accessibility/emulation features:
+  - **colorScheme** (light, dark, no-preference) - Emulates 'prefers-color-scheme' media feature
+  - **forcedColors** (active, none) - High contrast mode for accessibility
+  - **reducedMotion** (reduce, no-preference) - Emulates 'prefers-reduced-motion' for users sensitive to animations
+- **Evidence:** All three are:
+  - ✓ In device preset schema (`packages/device-presets/src/index.ts`)
+  - ✓ Displayed in UI hover cards (`DevicePresetHoverCard.tsx`)
+  - ✓ `colorScheme` has UI selector (`ColorSchemeSelector.tsx`)
+- **Action:** Add section "Accessibility & Emulation Features" covering these three settings with use cases
+- **Status:** ⏳ Update needed
 
-**Purpose:** Get list of QA.tech outbound IP addresses  
-**Auth:** None (public endpoint)  
-**Response:** `{ ipAddresses: string[] }`  
-**Action:** Add to API reference section (already in IP docs)
+#### 8. Ephemeral Test Cases in Chat
 
-### Browser Engine - Undocumented Features
+- **Target File:** `/best-practices/creating-tests.mdx` (add section)
+- **Why Medium:** Advanced chat feature, beneficial for power users
+- **What's Missing:** Documentation of ephemeral test case mode
+- **Key Points:**
+  - Test cases auto-generate and run without confirmation
+  - Useful for exploratory testing and long chains
+  - Automatically added to test case library
+  - Opt-in via conversation flow
+- **Code Reference:** `packages/mcp/src/tools/suggest-test-cases.ts` (isEphemeral flag)
+- **Action:** Add "Ephemeral Mode for Exploratory Testing" section to chat docs
+- **Status:** ⏳ Needs to be done
 
-#### HAR Recording & Playback - HIGH PRIORITY
+#### 9. Inline Test Case Suggestions (Chat UX)
 
-**What:** `BrowserSessionRecordOptions` with `record`, `play`, `harFile`  
-**Use Case:** Record once, replay tests without hitting live servers  
-**Features:** har.zip format, streaming JSON parsing, full HAR 1.2 spec  
-**Tests:** `iframe.test.ts`
+- **Target File:** `/best-practices/creating-tests.mdx` (update section)
+- **Why Medium:** UX change, users will discover naturally
+- **What Changed:** Refactored test suggestion UI in chat
+- **Key Points:**
+  - Individual test case generation on-demand (not batch-only)
+  - Real-time status tracking (started/finished/failed)
+  - Visual cards for each suggestion
+  - Accept/reject individual suggestions
+  - Extended with automatic deduplication
+- **Code Reference:** `apps/saas/src/components/Chat/messages/assistant/tools/suggestions/InlineToolCallSuggestTestCases.tsx`
+- **Action:** Update chat documentation with new UX flow, add screenshots
+- **Status:** ⏳ Needs to be done
 
-#### SSH Tunnel Proxy - HIGH PRIORITY
+#### 10. GET `/api/projects/{id}/badge.svg` - Status Badge API
 
-**What:** `SshProxyServerInput` for testing internal/VPN apps  
-**Package:** `@repo/ssh-tunnel-proxy`  
-**Parameters:** host, user, privateKey, sshPort  
-**Tests:** `ssh-tunnel-proxy.test.ts`
+- **Target File:** Update `/integrations/status-badges.mdx`
+- **Why Medium:** Existing integration docs may need API details
+- **Purpose:** Generate status badge SVG for embedding
+- **Auth:** Token via query param `?token={uuid}`
+- **Query Params:** `token` (required), `label?`, `style?` ('standard'|'flat'|'compact'), `showDate?`, `historyCount?`, `example?`
+- **Action:** Verify existing docs include all parameters and examples
+- **Status:** ⏳ Verify & update if needed
 
-#### Advanced File Picker - HIGH PRIORITY
+#### 11. Netlify Integration Page
 
-**What:** `window.showOpenFilePicker()` API support  
-**Features:** Drag-and-drop, Shadow DOM-based fake picker UI, scrollable list, file type filtering, multiple selection  
-**Providers:** SUPABASE, EXTERNAL_URL, DEV_LOCAL_PATH  
-**Tests:** `show-open-file-picker.test.ts`, `file-picker-scroll.test.ts`
+- **Target File:** Update navigation to include Netlify or create `/configuration/netlify.mdx`
+- **Why Medium:** Now first-class integration in UI
+- **Current Status:** May exist in core-concepts/preview-environments.mdx
+- **Key Points:** "Trigger tests after a successful deploy to Netlify"
+- **Code Reference:** `NETLIFY_INTEGRATION_CONFIG` in `INTEGRATION_CONFIGS.tsx`
+- **Action:** Verify if dedicated page needed or if preview-environments covers it
+- **Status:** ⏳ Investigate & decide
 
-#### Video Recording - HIGH PRIORITY
+### 🔵 LOW PRIORITY (Nice-to-Have)
 
-**What:** ffmpeg-based via CDP screencast  
-**Features:** Dynamic FPS (25 fps active, reduces when idle), WebM/VP8 format  
-**Parameter:** `tracerOptions.recordVideo`  
-**Tests:** `videoRecorder.test.ts`
+#### 12. POST `/api/projects/{id}/applications/{appId}/environments` - Create Environment API
 
-#### Session State Management - HIGH PRIORITY
+- **Why Low:** Advanced API, most users create via UI
+- **Purpose:** Create new environment for application
+- **Auth:** Bearer token
+- **Request:** `{ name: string (1-100 chars), url: string (valid URL), isPreview?: boolean }`
+- **Status:** ⏳ Low priority
 
-**What:** `storeOutputState` / `resumeOutputState` mutations  
-**Features:** Full browser state (cookies, localStorage, sessionStorage, IndexedDB)  
-**Tests:** `storeOutputState.test.ts`
+#### 13. GET `/api/outbound-ips` - Outbound IPs API
 
-#### CAPTCHA Handling - HIGH PRIORITY
+- **Why Low:** Already covered in IP docs content
+- **Purpose:** Get list of QA.tech outbound IP addresses
+- **Auth:** None (public endpoint)
+- **Action:** Add to API reference as public utility endpoint
+- **Status:** ⏳ Low priority
 
-**What:** Capsolver integration for Turnstile and FriendlyCaptcha  
-**Features:** Auto-detects submit buttons, generates tokens  
-**Location:** `apps/browser-engine/src/lib/browser/captcha/`  
-**Note:** Currently enabled only for specific whitelisted projects
+#### 14. Test Status Documentation (Draft vs Active)
 
-#### Device Preset System - HIGH PRIORITY
+- **Target File:** `/core-concepts/tests-and-results.mdx`
+- **Why Low:** Check UI tooltips first
+- **Issue:** Draft vs Active status not explicitly documented
+- **Status:** ⏳ Low priority - verify if needed
 
-**Package:** `@repo/device-presets`  
-**Features:** viewport, locale, timezone, user agent, colorScheme, forcedColors, reducedMotion, custom HTTP headers  
-**Presets:** desktop (1280x800), mobile (375x667), tablet (768x1024)
+---
 
-#### Dialog Capture - HIGH PRIORITY
+## ✅ Completed Tasks
 
-**What:** `captureDialogTypes` parameter in mutations  
-**Features:** Auto-accept/reject alert/confirm/prompt/beforeunload, text capture, iframe support  
-**Tests:** `alert-capture.test.ts`, `window-confirm.test.ts`
+- **Oct 2, 2025:** HTTP Basic Authentication Documentation - Added detailed explanation of "Use for Basic Auth" checkbox in Username + Password config section of `/core-concepts/configs.mdx`. Includes accordion with use cases (staging environments, browser auth popups, corporate proxies), distinction from form-based login, and implementation details (RFC 7617).
+- **Oct 2, 2025:** Documentation Backlog Audit - Comprehensive audit completed. Verified 5 features already have docs (SSH Tunnel, Dialog Handling, Device Presets, Output State, File Uploads). Identified Device Presets needs update for accessibility features. Removed 15 internal/not-customer-facing items.
+- **Oct 1, 2025:** Parallel Execution Documentation - Added "Performance & Parallel Execution" section to `/core-concepts/test-plans.mdx` explaining automatic parallelization (up to ~100 concurrent agents), dependency-aware scheduling, and auto-scaling. Added cross-reference note in `/best-practices/running-tests.mdx`.
+- **Oct 1, 2025:** IP Access Control - Merged comprehensive IP access control guidance combining CAPTCHA clarification with CDN/firewall configuration from PR #12. Includes Cloudflare AI Crawl Control (recommended), AWS CloudFront guidance, troubleshooting section, and expanded platform list. Supersedes [PR #12](https://github.com/QAdottech/docs/pull/12).
 
-#### Page Readiness - HIGH PRIORITY
+---
 
-**Functions:** `waitForPageReady()`, `waitForFCP()`, `waitForStableNetwork()`, `waitForMutation()`
+## 🗑️ REMOVED FROM BACKLOG (Not Customer-Facing / Already Documented)
 
-#### Medium Priority
+### Already Documented ✅ (No Update Needed)
 
-- Console Log Capture, Network Body Capture, Ad Blocker Integration
-- IndexedDB State Capture, Multi-Tab/Window Support
-- Iframe Advanced Handling, Custom HTTP Headers, Screenshot Types
+These features ARE customer-facing AND docs are current:
+
+1. **SSH Tunnel Proxy** ✅ - Documented in `/configuration/ssh-tunnel.mdx` - Comprehensive, up-to-date
+2. **Dialog Handling** ✅ - Documented in `/test-features/dialog-handling.mdx` - Covers alert, confirm, prompt, beforeunload
+3. **Session State Management** ✅ - Documented in `/core-concepts/output-state-optimization.mdx` - Covers dependency output states
+4. **File Uploads** ✅ - Documented in `/test-features/file-uploads.mdx` - Covers default files, custom uploads, configs
+
+### Already Documented ⚠️ (Needs Update)
+
+5. **Device Presets** ⚠️ - Documented in `/test-features/device-presets.mdx` BUT missing accessibility features (colorScheme, forcedColors, reducedMotion) - **Moved to Medium Priority #7**
+
+### Internal/Not Customer-Facing ❌
+
+These are internal development/testing features:
+
+1. **HAR Recording & Playback** ❌ - Internal testing tool, not exposed to customers
+2. **Video Recording** ❌ - Internal debugging feature, not exposed in SaaS UI
+3. **CAPTCHA Handling** ❌ - Hardcoded for specific whitelisted projects only (see `CAPSOLVER_ENABLED_PROJECT_IDS`)
+4. **Page Readiness Functions** ❌ - Internal browser engine implementation details
+5. **Advanced File Picker** ❌ - Internal browser API support, covered by basic file upload docs
+6. **Console Log Capture** ❌ - Internal debugging feature
+7. **Network Body Capture** ❌ - Internal debugging feature
+8. **Ad Blocker Integration** ❌ - Internal feature
+9. **IndexedDB State Capture** ❌ - Internal, part of Session State Management
+10. **Multi-Tab/Window Support** ❌ - Internal browser engine capability
+11. **Iframe Advanced Handling** ❌ - Internal browser engine capability
+12. **Custom HTTP Headers** ❌ - Documented in Device Presets (users can add via UI)
+13. **Screenshot Types** ❌ - Internal debugging feature
+14. **Get Applications MCP Tool** ❌ - Internal AI agent tool, not customer-facing API
+15. **Pull Request Debugger** ❌ - Internal troubleshooting UI, not a feature to document
 
 ---
 
 ## 📌 Reference Notes
 
+**Verification Process (Oct 2 Audit):**
+
+For each "already documented" feature, I:
+
+1. ✓ Read the existing documentation file
+2. ✓ Checked the code implementation in monorepo main
+3. ✓ Verified feature availability in UI/API
+4. ✓ Confirmed docs match current implementation
+
+**Docs Verified as Current:**
+
+- SSH Tunnel: `/configuration/ssh-tunnel.mdx` - Comprehensive 235-line guide
+- Dialog Handling: `/test-features/dialog-handling.mdx` - Covers all dialog types
+- Output State: `/core-concepts/output-state-optimization.mdx` - Complete feature docs
+- File Uploads: `/test-features/file-uploads.mdx` - Basic file upload functionality
+
+**Docs Needing Update:**
+
+- Device Presets: `/test-features/device-presets.mdx` - Missing colorScheme, forcedColors, reducedMotion
+
 **Code Locations (Sept 30 Audit):**
 
 - CHAT Trigger: `supabase/migrations/20250929124415_add_chat_trigger_type.sql`, `packages/types/src/run.ts`
-- Test Filtering UI: `apps/saas/src/app/dashboard/p/[project]/scenarios/components/ProjectTestCaseIsEnabledSwitch.tsx`
 - Browser Engine GraphQL: `apps/browser-engine/src/graphql/*.ts`, 130 test files analyzed
 - MCP Tools: `packages/mcp/src/agents/`, `packages/mcp/src/tools/`
 
-**Quick Audit Command:**
+**Code Locations (Oct 2 Audit - Main Branch Merge):**
+
+- GitHub App Integration: `apps/saas/src/app/dashboard/p/[project]/settings/integrations/[integrationId]/components/GitHubAppIntegrationSettings.tsx`
+- Prometheus Metrics: `apps/saas/src/app/dashboard/p/[project]/settings/integrations/[integrationId]/components/MetricsIntegrationSettings.tsx`
+- CAPTCHA (Internal Only): `apps/browser-engine/src/lib/browser/captcha/index.ts` - See `CAPSOLVER_ENABLED_PROJECT_IDS` (hardcoded single project)
+- Ephemeral Tests: `packages/mcp/src/tools/suggest-test-cases.ts` (isEphemeral flag)
+- Inline Test Suggestions: `apps/saas/src/components/Chat/messages/assistant/tools/suggestions/InlineToolCallSuggestTestCases.tsx`
+- Device Presets Schema: `packages/device-presets/src/index.ts` - colorScheme, forcedColors, reducedMotion in schema
+- Device Presets UI: `apps/saas/src/app/dashboard/p/[project]/settings/device-presets/components/advanced/ColorSchemeSelector.tsx`
+- Integration Configs: `apps/saas/src/app/dashboard/p/[project]/settings/integrations/[integrationId]/components/INTEGRATION_CONFIGS.tsx`
+- Merge Details: 176 files changed (+3,714/-3,045 lines)
+
+**Quick Audit Commands:**
 
 ```bash
+# Check recent API changes
 cd /Users/pridiuksson/Code/qatech
 git log --since="1 week ago" --oneline -- "apps/saas/src/app/api/**/*.ts"
+
+# Check type changes
 git log --since="1 week ago" --oneline -- "packages/types/**/*.ts"
+
+# Check DB migrations
 git log --since="1 week ago" --oneline -- "supabase/migrations/*.sql"
+
+# Check if feature is customer-facing (look for UI references)
+rg "featureName" apps/saas/src --type tsx
+
+# Verify accessibility features in device presets
+rg "colorScheme|forcedColors|reducedMotion" packages/device-presets/src
 ```
+
+**Prioritization Criteria:**
+
+1. **Critical** - Customer-facing, missing entirely, new integration/API
+2. **High** - Customer-facing API, incomplete docs, core functionality
+3. **Medium** - UX improvements, advanced features, doc updates, secondary integrations
+4. **Low** - Edge cases, rarely used, nice-to-have
+
+---
+
+## 📊 Summary
+
+**Total Items:** 14 active tasks  
+**Critical Priority:** 3 items  
+**High Priority:** 3 items  
+**Medium Priority:** 5 items (includes 1 doc update)  
+**Low Priority:** 3 items  
+**Already Documented:** 4 items ✅ (verified current)  
+**Needs Update:** 1 item ⚠️ (Device Presets)  
+**Internal/Removed:** 15 items ❌
+
+**Focus First:**
+
+1. Items 1-3 (GitHub App, Prometheus, CHAT trigger) for maximum customer impact
+2. Item 7 (Device Presets update) - Quick win, existing doc just needs accessibility section
+
+**Next Audit:** Review after next major merge to main (or monthly)


### PR DESCRIPTION
## Summary

Adds comprehensive documentation for the "Use for Basic Auth" checkbox in Username + Password configs.

## Changes

- Added detailed explanation in `/core-concepts/configs.mdx` under the Username + Password Credentials section
- Created expandable accordion section explaining when to enable Basic Auth
- Clarified distinction between HTTP Basic Auth (RFC 7617) and form-based login
- Included practical use cases: staging environments, browser auth popups, corporate proxies
- Updated `docs-update-plan.md` to track completion

## Context

Users encounter this checkbox when creating/editing Username + Password configs in Settings > Configs, but there was no documentation explaining what it does or when to use it.

## Documentation Structure

The explanation uses progressive disclosure (accordion) to keep the main page clean while providing detailed guidance for users who need it.