### PR TITLE
docs: add qatech CLI documentation (QAT-6070)

### DIFF
--- a/cli/commands/applications.mdx
+++ b/cli/commands/applications.mdx
@@ -1,0 +1,37 @@
+---
+title: 'qatech applications'
+description: 'List the applications in your QA.tech project.'
+icon: 'cube'
+---
+
+Lists every application in the project with its short ID and type (web or mobile). Use the short ID with [`qatech environments`](/cli/commands/environments) or with `--application-overrides` on [`qatech run`](/cli/commands/run) and [`qatech chat`](/cli/commands/chat).
+
+## Usage
+
+```bash
+qatech applications [options]
+```
+
+## Options
+
+| Flag              | Short | Description                  |
+| ----------------- | ----- | ---------------------------- |
+| `--json`          | `-j`  | Machine-readable output      |
+| `--api-key <key>` |       | Per-command API key override |
+| `--help`          | `-h`  | Show command help            |
+
+## Examples
+
+```bash
+qatech applications
+qatech applications --json
+```
+
+## Sample output
+
+```text
+Applications:
+
+  My Web App (app-myapp_Abc123) - web
+  My Mobile App (app-mymobile_Def456) - mobile
+```

--- a/cli/commands/chat.mdx
+++ b/cli/commands/chat.mdx
@@ -1,0 +1,101 @@
+---
+title: 'qatech chat'
+description: 'Talk to the QA.tech agent - get test IDs, ask about coverage, and run tests against custom URLs.'
+icon: 'comment'
+---
+
+Sends a message to the QA.tech agent. The agent knows your test cases, applications, and configurations, and returns test case IDs you can pipe directly into [`qatech run`](/cli/commands/run). Useful for both scripting (single-shot) and exploration (interactive REPL).
+
+## Usage
+
+```bash
+# Single-shot
+qatech chat [options] "<message>"
+
+# Interactive REPL
+qatech chat [options]
+
+# From stdin
+echo "<message>" | qatech chat
+qatech chat --stdin <<'EOF'
+<message>
+EOF
+```
+
+## Options
+
+| Flag                             | Short | Description                                                   |
+| -------------------------------- | ----- | ------------------------------------------------------------- |
+| `--conversation <id>`            | `-c`  | Continue an existing conversation (chat short ID)             |
+| `--application-overrides <json>` |       | Override application target URLs as a JSON array              |
+| `--json`                         | `-j`  | Machine-readable output (single-shot only)                    |
+| `--stdin`                        |       | Force reading the message from stdin even when stdin is a TTY |
+| `--api-key <key>`                |       | Per-command API key override                                  |
+| `--help`                         | `-h`  | Show command help                                             |
+
+## Modes
+
+- **Single-shot** - pass a message argument or pipe stdin. Streams the agent's response, then exits.
+- **Interactive** - invoked with no message on a TTY. Drops you into a REPL; type `exit` or `quit` to leave.
+- **Resume** - pass `-c <chat-short-id>` to continue a previous conversation in either mode.
+
+## Examples
+
+```bash
+# Ask a question
+qatech chat "What tests cover the checkout flow?"
+
+# Pipe IDs into a run
+ID=$(qatech chat --json "Most critical login test, just the ID" | jq -r '.content')
+qatech run -c "$ID" --wait
+
+# Continue a conversation
+qatech chat -c chat_abc123 "Now run those tests"
+
+# Interactive REPL
+qatech chat
+```
+
+## Testing against a custom URL
+
+When you want the agent to test against a URL that isn't a configured environment - e.g. a tunnel from [`qatech tunnel`](/cli/commands/tunnel) or a PR preview - pass `--application-overrides`:
+
+```bash
+qatech chat --application-overrides '[{
+  "applicationShortId": "app-myapp_Abc123",
+  "environment": {"url": "https://preview.example.com"}
+}]' "Test the login flow"
+```
+
+For multiple apps:
+
+```bash
+qatech chat --application-overrides '[
+  {"applicationShortId": "app-myapp_Abc123",  "environment": {"url": "https://web.preview.example.com"}},
+  {"applicationShortId": "app-myapi_Def456", "environment": {"url": "https://api.preview.example.com"}}
+]' "Run the full test suite"
+```
+
+The `environment` object accepts any of:
+
+| Form                                     | When to use                                 |
+| ---------------------------------------- | ------------------------------------------- |
+| `{"url": "..."}`                         | Inline URL override (tunnel, preview, etc.) |
+| `{"shortId": "env_xxx"}`                 | Reuse a saved environment                   |
+| `{"applicationBuildShortId": "bld_xxx"}` | Pin to a specific build                     |
+
+<Note>
+  Application overrides apply to the **first** message of a conversation. When
+  resuming with `-c`, the existing conversation already has its environment.
+</Note>
+
+## JSON output
+
+```json
+{
+  "conversationShortId": "chat_abc123",
+  "messageId": "e5f6g7h8-...",
+  "content": "Here are the tests covering checkout: ...",
+  "url": "https://app.qa.tech/..."
+}
+```

--- a/cli/commands/configure.mdx
+++ b/cli/commands/configure.mdx
@@ -1,0 +1,58 @@
+---
+title: 'qatech configure'
+description: 'Set up and inspect your QA.tech CLI credentials.'
+icon: 'gear'
+---
+
+Configures the CLI with your QA.tech API key. By default the key is saved to `.qatech/config.json` in the current directory so each project can have its own key. Use `--global` to write to `~/.qatech/config.json` as a fallback.
+
+## Usage
+
+```bash
+qatech configure [options]
+```
+
+## Options
+
+| Flag              | Short | Description                                                   |
+| ----------------- | ----- | ------------------------------------------------------------- |
+| `--api-key <key>` | `-k`  | Set the API key (saves to local config by default)            |
+| `--global`        | `-g`  | Save to `~/.qatech/config.json` instead of project-local      |
+| `--show`          | `-s`  | Show the active configuration and where each value comes from |
+| `--help`          | `-h`  | Show command help                                             |
+
+## Examples
+
+```bash
+# Interactive setup (saves locally)
+qatech configure
+
+# Non-interactive - set the project-local key
+qatech configure -k <your-api-key>
+
+# Set the global fallback key
+qatech configure -k <your-api-key> --global
+
+# Inspect what the CLI is using
+qatech configure --show
+```
+
+## Resolution order
+
+The resolved key is the first match from:
+
+1. `--api-key` flag on the running command
+2. `QATECH_API_KEY` environment variable
+3. `.qatech/config.json` in the current directory (project-local)
+4. `~/.qatech/config.json` (global fallback)
+
+`qatech configure --show` reports the active key (masked), the source it came from, and both config file paths so you can see exactly which file you're editing.
+
+## Security
+
+The config file stores your raw API key - treat it like any other credential. Add `.qatech/` to your `.gitignore` if you want to keep project-local keys out of source control.
+
+<Tip>
+  Get your API key from [app.qa.tech](https://app.qa.tech) → **Settings →
+  Integrations → API**.
+</Tip>

--- a/cli/commands/environments.mdx
+++ b/cli/commands/environments.mdx
@@ -1,0 +1,43 @@
+---
+title: 'qatech environments'
+description: 'List the environments configured for an application.'
+icon: 'cubes'
+---
+
+Lists the non-preview environments for a given application along with each environment's URL and short ID.
+
+## Usage
+
+```bash
+qatech environments <application-short-id> [options]
+```
+
+## Arguments
+
+| Argument                 | Description                                                                                                           |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------- |
+| `<application-short-id>` | The application short ID (e.g. `app-myapp_Abc123`). Find it with [`qatech applications`](/cli/commands/applications). |
+
+## Options
+
+| Flag              | Short | Description                  |
+| ----------------- | ----- | ---------------------------- |
+| `--json`          | `-j`  | Machine-readable output      |
+| `--api-key <key>` |       | Per-command API key override |
+| `--help`          | `-h`  | Show command help            |
+
+## Examples
+
+```bash
+qatech environments app-myapp_Abc123
+qatech environments app-myapp_Abc123 --json
+```
+
+## Sample output
+
+```text
+Environments for app-myapp_Abc123:
+
+  Production: https://app.example.com (env_abc123) [production]
+  Staging:    https://staging.example.com (env_def456)
+```

--- a/cli/commands/init.mdx
+++ b/cli/commands/init.mdx
@@ -1,0 +1,58 @@
+---
+title: 'qatech init'
+description: 'Generate Claude Code subagent and skill files for the QA.tech CLI.'
+icon: 'wand-magic-sparkles'
+---
+
+`qatech init` writes two files into the current project that teach Claude Code how to use this CLI:
+
+```
+.claude/agents/qa-runner.md             # subagent definition
+.claude/skills/qa-tech-cli/SKILL.md     # full CLI reference for the agent
+```
+
+These files contain no credentials and are safe to commit to your repo. Re-run with `--force` after upgrading the CLI to pull in the latest skill and agent content.
+
+## Usage
+
+```bash
+qatech init [options]
+```
+
+## Options
+
+| Flag           | Short | Description                                           |
+| -------------- | ----- | ----------------------------------------------------- |
+| `--dir <path>` | `-d`  | Target project directory (default: current directory) |
+| `--force`      | `-f`  | Overwrite existing files (useful after CLI upgrades)  |
+| `--help`       | `-h`  | Show command help                                     |
+
+## Examples
+
+```bash
+# Create files in the current project
+qatech init
+
+# Initialize a different project
+qatech init --dir /path/to/project
+
+# Refresh after upgrading the CLI
+qatech init --force
+```
+
+## What you get
+
+After running `qatech init`, Claude Code (or any agent that reads `.claude/`) can:
+
+- Invoke the `qa-runner` subagent via the **Task** tool to run E2E tests in the background.
+- Read the `qa-tech-cli` skill - a complete CLI reference with examples, ID formats, JSON shapes, and error handling - whenever it needs to use `qatech`.
+
+## Updating after CLI upgrades
+
+The skill and agent files are baked into the CLI itself, so they evolve as the CLI evolves. After `npm install -g qatech@latest`, run:
+
+```bash
+qatech init --force
+```
+
+…in each project that has the integration installed, then commit the diff.

--- a/cli/commands/run.mdx
+++ b/cli/commands/run.mdx
@@ -1,0 +1,107 @@
+---
+title: 'qatech run'
+description: 'Start a test run by test plan or individual test cases.'
+icon: 'play'
+---
+
+Starts a QA.tech test run. Pass either a test plan or one or more individual test cases. With `--wait`, the command polls until completion and exits non-zero on failure.
+
+## Usage
+
+```bash
+qatech run (-t <test-plan-id> | -c <test-case-id> ...) [options]
+```
+
+You must provide either `--test-plan` **or** one or more `--test-case` flags - not both.
+
+## Options
+
+| Flag                             | Short | Description                                                                              |
+| -------------------------------- | ----- | ---------------------------------------------------------------------------------------- |
+| `--test-plan <id>`               | `-t`  | Test plan short ID (e.g. `pln_abc123`)                                                   |
+| `--test-case <id>`               | `-c`  | Test case UUID (repeatable)                                                              |
+| `--application-overrides <json>` |       | JSON array of application overrides - point apps at custom URLs, environments, or builds |
+| `--wait`                         | `-w`  | Poll until the run finishes, then print results                                          |
+| `--poll-interval <secs>`         |       | How often to check status when waiting (default: `5`)                                    |
+| `--timeout <secs>`               |       | Max time to wait before giving up (default: `600`)                                       |
+| `--json`                         | `-j`  | Machine-readable output. Progress goes to stderr.                                        |
+| `--api-key <key>`                |       | Per-command API key override                                                             |
+| `--help`                         | `-h`  | Show command help                                                                        |
+
+## Behavior
+
+- **Without `--wait`** - prints the run short ID and exits immediately.
+- **With `--wait`** - polls until `COMPLETED`, `ERROR`, or `CANCELLED`, then prints results.
+- Exit code is `1` if any test case ends as `FAILED`, `0` otherwise.
+- With `--wait --json`, progress logs go to stderr so stdout stays clean JSON.
+
+## Examples
+
+```bash
+# Run a full test plan and wait for results
+qatech run -t pln_abc123 --wait
+
+# Run specific test cases
+qatech run -c 636a990b-85e7-44c2-8175-58390f2184a3 --wait
+
+# Run multiple test cases with JSON output
+qatech run -c <id1> -c <id2> -w --json
+
+# Run against a preview deployment
+qatech run -t pln_abc123 \
+  --application-overrides '[{"applicationShortId":"app-myapp_Abc123","environment":{"url":"https://preview.example.com"}}]' \
+  --wait
+
+# Fire-and-forget - check later with `qatech status`
+qatech run -t pln_abc123
+```
+
+## Application overrides
+
+`--application-overrides` redirects one or more applications to a different URL, saved environment, or build for this run. Same JSON shape as [`qatech chat --application-overrides`](/cli/commands/chat) - useful for testing preview deployments, tunnels from [`qatech tunnel`](/cli/commands/tunnel), or any URL not configured as a saved environment.
+
+```bash
+qatech run -t pln_abc123 \
+  --application-overrides '[
+    {"applicationShortId": "app-myapp_Abc123",  "environment": {"url": "https://web.preview.example.com"}},
+    {"applicationShortId": "app-myapi_Def456", "environment": {"url": "https://api.preview.example.com"}}
+  ]' \
+  --wait --json
+```
+
+The `environment` object accepts any of:
+
+| Form                                     | When to use                                 |
+| ---------------------------------------- | ------------------------------------------- |
+| `{"url": "..."}`                         | Inline URL override (tunnel, preview, etc.) |
+| `{"shortId": "env_xxx"}`                 | Reuse a saved environment                   |
+| `{"applicationBuildShortId": "bld_xxx"}` | Pin to a specific build                     |
+
+## JSON output
+
+The shape returned by `qatech run --wait --json` matches [`qatech status --json`](/cli/commands/status):
+
+```json
+{
+  "shortId": "UkxK",
+  "status": "COMPLETED",
+  "result": "PASSED",
+  "runTestCases": [
+    {
+      "id": "636a990b-...",
+      "shortId": "AbCd",
+      "name": "Login with valid credentials",
+      "status": "COMPLETED",
+      "result": "PASSED",
+      "resultTitle": null,
+      "evaluationThought": "The test passed because..."
+    }
+  ]
+}
+```
+
+Key fields:
+
+- `result` - `"PASSED" | "FAILED" | "SKIPPED" | null`
+- `runTestCases[].resultTitle` - human-readable failure reason (`null` if passed)
+- `runTestCases[].evaluationThought` - agent's reasoning about the result

--- a/cli/commands/status.mdx
+++ b/cli/commands/status.mdx
@@ -1,0 +1,81 @@
+---
+title: 'qatech status'
+description: 'Check or wait for the result of a test run.'
+icon: 'circle-check'
+---
+
+Returns the current status of a run, or polls until it finishes. Use this when you started a run with `qatech run` (without `--wait`) and want to check on it later.
+
+## Usage
+
+```bash
+qatech status <run-id> [options]
+```
+
+## Arguments
+
+| Argument   | Description                                                                                                 |
+| ---------- | ----------------------------------------------------------------------------------------------------------- |
+| `<run-id>` | Run short ID (e.g. `UkxK`). Returned by [`qatech run`](/cli/commands/run) and visible in the dashboard URL. |
+
+## Options
+
+| Flag                     | Short | Description                                           |
+| ------------------------ | ----- | ----------------------------------------------------- |
+| `--wait`                 | `-w`  | Poll until the run completes, then print results      |
+| `--poll-interval <secs>` |       | How often to check status when waiting (default: `5`) |
+| `--timeout <secs>`       |       | Max time to wait before giving up (default: `600`)    |
+| `--json`                 | `-j`  | Machine-readable output                               |
+| `--api-key <key>`        |       | Per-command API key override                          |
+| `--help`                 | `-h`  | Show command help                                     |
+
+## Run statuses
+
+| Status      | Meaning                                                   |
+| ----------- | --------------------------------------------------------- |
+| `INITIATED` | Queued, not yet executing                                 |
+| `RUNNING`   | Tests are running                                         |
+| `COMPLETED` | All tests finished - check `result` for `PASSED`/`FAILED` |
+| `ERROR`     | Run failed due to an infrastructure error                 |
+| `CANCELLED` | Run was cancelled before completion                       |
+
+Exit code is `1` if `result` is `FAILED`, `0` otherwise.
+
+## Examples
+
+```bash
+# One-shot status check
+qatech status UkxK
+
+# Block until finished
+qatech status UkxK --wait
+
+# Wait, then get JSON
+qatech status UkxK --wait --json
+
+# Just the top-line result
+qatech status UkxK -j | jq '.result'
+```
+
+## JSON output
+
+```json
+{
+  "shortId": "UkxK",
+  "status": "COMPLETED",
+  "result": "FAILED",
+  "runTestCases": [
+    {
+      "id": "636a990b-...",
+      "shortId": "AbCd",
+      "name": "Checkout with saved card",
+      "status": "COMPLETED",
+      "result": "FAILED",
+      "resultTitle": "Card form did not submit",
+      "evaluationThought": "..."
+    }
+  ]
+}
+```
+
+Without `--wait`, the response only includes failed test cases (`testCases=failed` server-side). With `--wait`, you get the full set.

--- a/cli/commands/test-cases.mdx
+++ b/cli/commands/test-cases.mdx
@@ -1,0 +1,77 @@
+---
+title: 'qatech test-cases'
+description: 'List and search test cases in your project.'
+icon: 'list-check'
+---
+
+Lists the test cases in your project. Each test case has a UUID that you can pass to `qatech run -c <id>` to execute it.
+
+## Usage
+
+```bash
+qatech test-cases [options]
+```
+
+## Options
+
+| Flag                      | Short | Description                                                     |
+| ------------------------- | ----- | --------------------------------------------------------------- |
+| `--application <id>`      | `-a`  | Filter by application short ID (e.g. `app-myapp_Abc123`)        |
+| `--labels <labels>`       | `-l`  | Filter by labels (comma-separated, e.g. `smoke,critical`)       |
+| `--search <query>`        | `-s`  | Filter by name or goal text (case-insensitive, applied locally) |
+| `--enabled <true\|false>` |       | Filter by enabled/disabled status                               |
+| `--limit <n>`             |       | Max results per page (default: 100, max: 1000)                  |
+| `--offset <n>`            |       | Pagination offset (default: 0)                                  |
+| `--json`                  | `-j`  | Machine-readable output                                         |
+| `--api-key <key>`         |       | Per-command API key override                                    |
+| `--help`                  | `-h`  | Show command help                                               |
+
+`--application`, `--labels`, and `--enabled` are server-side filters. `--search` is applied locally to the returned page, so combine it with the server-side filters when you have many test cases.
+
+## Examples
+
+```bash
+# List the first 100 test cases
+qatech test-cases
+
+# Find login-related tests
+qatech test-cases --search "login"
+
+# Combine filters
+qatech test-cases --enabled true -a app-myapp_Abc123 -l smoke,critical
+
+# Pagination
+qatech test-cases --offset 100 --limit 100
+
+# Extract every test case ID
+qatech test-cases --json | jq '.testCases[].id'
+```
+
+## JSON output
+
+```json
+{
+  "testCases": [
+    {
+      "id": "636a990b-85e7-44c2-8175-58390f2184a3",
+      "name": "Login with valid credentials",
+      "isEnabled": true,
+      "labels": ["smoke", "auth"],
+      "applicationShortId": "app-myapp_Abc123",
+      "applicationName": "My App",
+      "goal": "Verify user can log in",
+      "lastRun": {
+        "runShortId": "UkxK",
+        "status": "COMPLETED",
+        "result": "PASSED",
+        "completedAt": "2026-02-26T12:00:00Z"
+      }
+    }
+  ],
+  "total": 42,
+  "limit": 100,
+  "offset": 0
+}
+```
+
+Use the `id` field with [`qatech run -c <id>`](/cli/commands/run).

--- a/cli/commands/tunnel.mdx
+++ b/cli/commands/tunnel.mdx
@@ -1,0 +1,97 @@
+---
+title: 'qatech tunnel'
+description: 'Expose local ports to QA.tech and run tests against your dev server.'
+icon: 'link'
+---
+
+Exposes local ports to QA.tech so the agent can reach your dev server during testing. Pair with `--application-overrides` on [`qatech run`](/cli/commands/run) or [`qatech chat`](/cli/commands/chat) to point a test run at the tunnel URL.
+
+## Usage
+
+```bash
+qatech tunnel start [options]    # start a tunnel
+qatech tunnel list               # list active tunnels for your project
+qatech tunnel status <runner-id> # check tunnel health
+qatech tunnel stop <runner-id>   # tear down a tunnel
+```
+
+## Global flags
+
+These work on every subcommand:
+
+| Flag              | Short | Description                            |
+| ----------------- | ----- | -------------------------------------- |
+| `--api-key <key>` | `-k`  | API key override (or `QATECH_API_KEY`) |
+| `--api-url <url>` |       | API base URL (or `QATECH_API_URL`)     |
+| `--help`          | `-h`  | Show subcommand help                   |
+
+## `qatech tunnel start`
+
+Starts a tunnel and prints a manifest of public URLs, one per port.
+
+| Flag             | Short | Description                                                      |
+| ---------------- | ----- | ---------------------------------------------------------------- |
+| `--port <ports>` | `-p`  | Ports to expose, comma-separated, with optional labels           |
+| `--https`        |       | Local services use HTTPS (default: HTTP)                         |
+| `--public`       |       | Make the tunnel publicly accessible (no authentication required) |
+
+### Port syntax
+
+| Form        | Example                    | Result                   |
+| ----------- | -------------------------- | ------------------------ |
+| Single port | `--port 3000`              | One tunnel for port 3000 |
+| Multi-port  | `--port 3000,8080`         | One tunnel host per port |
+| Labelled    | `--port 3000:web,4000:api` | Hostnames keyed by label |
+
+A labelled multi-port tunnel returns a manifest with one URL per label:
+
+```text
+web -> https://web-<id>.quack.run
+api -> https://api-<id>.quack.run
+```
+
+### Examples
+
+```bash
+# Single port
+qatech tunnel start --port 3000
+
+# Multiple ports with labels
+qatech tunnel start --port 3000:web,4000:api
+
+# Public tunnel (no auth wrapper)
+qatech tunnel start --port 3000 --public
+
+# Local server uses HTTPS
+qatech tunnel start --port 8443 --https
+
+# Use the tunnel URL in a run
+qatech tunnel start --port 3000
+qatech run -t pln_abc123 \
+  --application-overrides '[{"applicationShortId":"app-myapp_Abc123","environment":{"url":"https://<tunnel-host>.quack.run"}}]' \
+  --wait
+```
+
+## `qatech tunnel list`
+
+```bash
+qatech tunnel list
+```
+
+Lists every active tunnel for the project - runner ID, port mapping, and public URLs.
+
+## `qatech tunnel status`
+
+```bash
+qatech tunnel status <runner-id>
+```
+
+Returns the live health status of a single tunnel.
+
+## `qatech tunnel stop`
+
+```bash
+qatech tunnel stop <runner-id>
+```
+
+Tears down a tunnel and cleans up its resources. If the tunnel process is still running in another terminal, it will exit on its own within ~30 seconds.

--- a/cli/overview.mdx
+++ b/cli/overview.mdx
@@ -1,0 +1,92 @@
+---
+title: 'CLI Overview'
+description: 'Run QA.tech tests, inspect results, expose local servers, and chat with the QA.tech agent from the terminal.'
+icon: 'terminal'
+---
+
+# qatech CLI
+
+`qatech` is the official command-line tool for [QA.tech](https://qa.tech). It lets you run end-to-end tests, inspect results, expose local servers via tunnels, and chat with the QA.tech agent - all from the terminal.
+
+The CLI is designed to be **agent-friendly**: every command supports `--json` output, `--help` with copy-pasteable examples, and exits non-zero on failure so AI coding agents can drive it reliably from your terminal.
+
+## Install
+
+```bash
+npm install -g qatech
+```
+
+Requires Node.js 18+.
+
+## Quick start
+
+<Steps>
+  <Step title="Get an API key">
+    Sign in at [app.qa.tech](https://app.qa.tech) → **Settings → Integrations → API**.
+  </Step>
+  <Step title="Configure the CLI">
+    ```bash
+    qatech configure -k <your-api-key>
+    ```
+    The key is saved to `.qatech/config.json` in the current directory by default.
+  </Step>
+  <Step title="Discover your tests">
+    ```bash
+    qatech test-cases
+    ```
+  </Step>
+  <Step title="Run a test">
+    ```bash
+    qatech run -c <test-case-id> --wait
+    ```
+    Streams progress to your terminal and exits with code `1` if any test fails.
+  </Step>
+</Steps>
+
+## Commands
+
+| Command                                      | Description                                   |
+| -------------------------------------------- | --------------------------------------------- |
+| [`configure`](/cli/commands/configure)       | Set up API credentials                        |
+| [`test-cases`](/cli/commands/test-cases)     | List and search test cases                    |
+| [`applications`](/cli/commands/applications) | List applications in the project              |
+| [`environments`](/cli/commands/environments) | List environments for an application          |
+| [`run`](/cli/commands/run)                   | Start a test run                              |
+| [`status`](/cli/commands/status)             | Check or wait for a run's results             |
+| [`chat`](/cli/commands/chat)                 | Chat with the QA.tech agent                   |
+| [`tunnel`](/cli/commands/tunnel)             | Expose local ports via tunnels                |
+| [`init`](/cli/commands/init)                 | Generate Claude Code subagent and skill files |
+
+Run `qatech <command> --help` for detailed flags on any command.
+
+## Configuration resolution
+
+The CLI resolves credentials in this order - first match wins:
+
+1. `--api-key` flag (per-command override)
+2. `QATECH_API_KEY` environment variable
+3. `.qatech/config.json` in the current directory (project-local)
+4. `~/.qatech/config.json` (global fallback)
+
+| Environment variable | Description                                   |
+| -------------------- | --------------------------------------------- |
+| `QATECH_API_KEY`     | API key                                       |
+| `QATECH_API_URL`     | API base URL (default: `https://api.qa.tech`) |
+| `QATECH_DEBUG`       | Set to `1` for stack traces on errors         |
+
+## Output conventions
+
+- **stdout** → data (JSON or human-readable results)
+- **stderr** → progress messages, errors, hints
+- With `--json`, stdout is always valid JSON - safe to pipe to `jq`
+- Errors with `--json` are also JSON: `{ "error": true, "message": "...", "statusCode": 401 }`
+
+This split lets you pipe results into `jq` cleanly:
+
+```bash
+qatech run -t pln_abc123 --wait --json | jq '.runTestCases[] | select(.result == "FAILED")'
+```
+
+## See also
+
+- [API reference](/api-reference/introduction)

--- a/mint.json
+++ b/mint.json
@@ -134,6 +134,26 @@
       "pages": ["applications/se-bank-id"]
     },
     {
+      "group": "CLI",
+      "pages": [
+        "cli/overview",
+        {
+          "group": "Commands",
+          "pages": [
+            "cli/commands/configure",
+            "cli/commands/test-cases",
+            "cli/commands/applications",
+            "cli/commands/environments",
+            "cli/commands/run",
+            "cli/commands/status",
+            "cli/commands/chat",
+            "cli/commands/tunnel",
+            "cli/commands/init"
+          ]
+        }
+      ]
+    },
+    {
       "group": "API Reference",
       "pages": [
         "api-reference/introduction",


### PR DESCRIPTION
## Summary
- Adds an external-facing reference for the qatech CLI: overview, configuration, and one page per command (configure, test-cases, applications, environments, run, status, chat, tunnel, init)
- Wires the new section into mint.json as a CLI group with a Commands subgroup

## Test plan
- [ ] Preview the docs site and confirm the CLI group + Commands subgroup render in the sidebar
- [ ] Click through each command page and verify formatting, code blocks, and links
- [ ] Verify mint.json changes don't break navigation for existing pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)