### PR TITLE
Add documentation for undocumented API endpoints

### DIFF
--- a/api-reference/api.json
+++ b/api-reference/api.json
@@ -3,11 +3,401 @@
   "info": {
     "title": "QA.tech API",
     "version": "1.0.0",
-    "description": "API for managing test runs, test cases, and project configuration"
+    "contact": {
+      "name": "QA.tech",
+      "url": "https://qa.tech",
+      "email": "support@qa.tech"
+    },
+    "description": "REST API for triggering and managing AI-powered test runs. Authenticate with a project API token (Authorization: Bearer <token>) found in Project Settings -> Integrations."
   },
-  "tags": [],
+  "tags": [
+    {
+      "name": "Runs"
+    },
+    {
+      "name": "Infrastructure"
+    },
+    {
+      "name": "Test Cases"
+    },
+    {
+      "name": "Application Builds"
+    },
+    {
+      "name": "Status badge"
+    },
+    {
+      "name": "Remote Tunnels"
+    },
+    {
+      "name": "Chat"
+    },
+    {
+      "name": "Applications"
+    }
+  ],
   "paths": {
-    "/outbound-ips": {
+    "/v1/applications": {
+      "get": {
+        "operationId": "ListApplications",
+        "description": "List all applications for the project",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListApplicationsResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Applications"
+        ],
+        "summary": "List applications"
+      }
+    },
+    "/v1/applications/{applicationShortId}/builds": {
+      "post": {
+        "operationId": "ApplicationBuildCreate",
+        "description": "Create an application build record from a previously uploaded file. Use buildShortId in run API with environment.applicationBuildShortId.",
+        "parameters": [
+          {
+            "name": "applicationShortId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ApplicationShortId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApplicationBuildCreateResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Application Builds"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApplicationBuildCreateRequest"
+              }
+            }
+          }
+        },
+        "summary": "Create application build"
+      }
+    },
+    "/v1/applications/{applicationShortId}/builds/upload-url": {
+      "post": {
+        "operationId": "ApplicationBuildUploadUrl",
+        "description": "Get a presigned URL to upload a build file directly to storage",
+        "parameters": [
+          {
+            "name": "applicationShortId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ApplicationShortId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApplicationBuildUploadUrlResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Application Builds"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApplicationBuildUploadUrlRequest"
+              }
+            }
+          }
+        },
+        "summary": "Get build upload URL"
+      }
+    },
+    "/v1/applications/{applicationShortId}/environments": {
+      "get": {
+        "operationId": "ListApplicationEnvironments",
+        "description": "List environments for a specific application",
+        "parameters": [
+          {
+            "name": "applicationShortId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ApplicationShortId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListApplicationEnvironmentsResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Applications"
+        ],
+        "summary": "List application environments"
+      }
+    },
+    "/v1/badge-example.svg": {
+      "get": {
+        "operationId": "GetStatusBadgeExampleSvg",
+        "description": "Get a sample status badge as SVG (no token). For live project badges use GET /v1/badge.svg.",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/BadgeExampleSvgQuery"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Status badge"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Get example status badge"
+      }
+    },
+    "/v1/badge.svg": {
+      "get": {
+        "operationId": "GetStatusBadgeSvg",
+        "description": "Get status badge as SVG. Authenticate with the token query parameter (not the API Bearer key). Project is resolved from the token.",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/BadgeSvgQuery"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Status badge"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Get status badge"
+      }
+    },
+    "/v1/chat": {
+      "post": {
+        "operationId": "Chat",
+        "description": "Create a new chat conversation and send its first message.\n\nReturns 202 immediately with the created conversation. Processing is asynchronous: poll\n`GET /chat/{chatConversationShortId}` until the latest assistant message has\n`status: 'COMPLETED'` to read the reply.",
+        "parameters": [],
+        "responses": {
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChatConversationResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Chat"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChatRequest"
+              }
+            }
+          }
+        },
+        "summary": "Start chat conversation"
+      }
+    },
+    "/v1/chat/change-review": {
+      "post": {
+        "operationId": "StartChangeReviewChat",
+        "description": "Create a new chat conversation and start an autonomous change review from either a PR URL or raw change input.",
+        "parameters": [],
+        "responses": {
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChatConversationResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Chat"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StartChangeReviewRequest"
+              }
+            }
+          }
+        },
+        "summary": "Start change review chat"
+      }
+    },
+    "/v1/chat/{chatConversationShortId}": {
+      "post": {
+        "operationId": "AppendChatMessage",
+        "description": "Send a chat message to an existing conversation.\n\nReturns 202 immediately. Poll `GET /chat/{chatConversationShortId}` until the latest\nassistant message has `status: 'COMPLETED'` to read the reply.",
+        "parameters": [
+          {
+            "name": "chatConversationShortId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ChatConversationShortId"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChatConversationResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Chat"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChatRequest"
+              }
+            }
+          }
+        },
+        "summary": "Send chat message"
+      },
+      "get": {
+        "operationId": "GetChatConversation",
+        "description": "Get conversation metadata and recent messages (newest first).\n\nUse `limit` to control how many messages are returned (default 20). To detect when an\nassistant reply is finished, poll until the most recent `assistant` message has\n`status: 'COMPLETED'` (or `CANCELLED`/`FAILED`).",
+        "parameters": [
+          {
+            "name": "chatConversationShortId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ChatConversationShortId"
+            }
+          },
+          {
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/GetChatConversationQuery"
+            },
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChatConversationResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Chat"
+        ],
+        "summary": "Get chat conversation"
+      }
+    },
+    "/v1/outbound-ips": {
       "get": {
         "operationId": "GetOutboundIps",
         "description": "Get outbound IP addresses",
@@ -22,29 +412,136 @@
                 }
               }
             }
-          },
-          "500": {
-            "description": "Server error",
+          }
+        },
+        "tags": [
+          "Infrastructure"
+        ],
+        "summary": "Get outbound IPs"
+      }
+    },
+    "/v1/remote-tunnels": {
+      "post": {
+        "operationId": "CreateRemoteTunnel",
+        "description": "Create a new remote tunnel that exposes local ports via Cloudflare. Returns a tunnelToken to start the cloudflared daemon.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/CreateRemoteTunnelResponse"
                 }
               }
             }
           }
-        }
+        },
+        "tags": [
+          "Remote Tunnels"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateRemoteTunnelRequest"
+              }
+            }
+          }
+        },
+        "summary": "Create remote tunnel"
+      },
+      "get": {
+        "operationId": "ListRemoteTunnels",
+        "description": "List remote tunnels for the authenticated project",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListRemoteTunnelsResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Remote Tunnels"
+        ],
+        "summary": "List remote tunnels"
       }
     },
-    "/run": {
+    "/v1/remote-tunnels/{runnerId}": {
+      "delete": {
+        "operationId": "DeleteRemoteTunnel",
+        "description": "Tear down a remote tunnel and its DNS records",
+        "parameters": [
+          {
+            "name": "runnerId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteRemoteTunnelResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Remote Tunnels"
+        ],
+        "summary": "Delete remote tunnel"
+      }
+    },
+    "/v1/remote-tunnels/{runnerId}/status": {
+      "get": {
+        "operationId": "GetRemoteTunnelStatus",
+        "description": "Get the live Cloudflare health status of a remote tunnel",
+        "parameters": [
+          {
+            "name": "runnerId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RemoteTunnelStatusResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Remote Tunnels"
+        ],
+        "summary": "Get remote tunnel status"
+      }
+    },
+    "/v1/run": {
       "post": {
         "operationId": "RunProject",
-        "description": "Execute a run for a given project",
+        "description": "Execute a run for a given project. Supports API or GITHUB trigger. When using GITHUB trigger, provide actor, branch, commitHash, commitMessage, and repository. Use applications to override environment or device preset per run.",
         "parameters": [],
         "responses": {
           "200": {
@@ -56,100 +553,13 @@
                 }
               }
             }
-          },
-          "400": {
-            "description": "Validation error or bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Missing or invalid API key",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "402": {
-            "description": "Usage limit exceeded",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Account suspended or invalid token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
           }
         },
+        "tags": [
+          "Runs"
+        ],
         "requestBody": {
-          "required": false,
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -158,14 +568,10 @@
             }
           }
         },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        "summary": "Start test run"
       }
     },
-    "/run/{shortId}": {
+    "/v1/run/{shortId}": {
       "get": {
         "operationId": "GetRun",
         "description": "Get a run by shortId with test cases",
@@ -179,17 +585,13 @@
             }
           },
           {
-            "name": "testCases",
+            "name": "query",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
-              "type": "string",
-              "enum": [
-                "failed",
-                "all"
-              ]
+              "$ref": "#/components/schemas/GetRunQuery"
             },
-            "description": "Return run with test cases: \"failed\" (only failed/skipped/error) or \"all\""
+            "explode": false
           }
         ],
         "responses": {
@@ -202,73 +604,12 @@
                 }
               }
             }
-          },
-          "400": {
-            "description": "Validation error or bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Missing or invalid API key",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Account suspended or invalid token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
           }
         },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        "tags": [
+          "Runs"
+        ],
+        "summary": "Get run"
       },
       "post": {
         "operationId": "RerunRunOp",
@@ -293,98 +634,11 @@
                 }
               }
             }
-          },
-          "400": {
-            "description": "Validation error or bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Missing or invalid API key",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "402": {
-            "description": "Usage limit exceeded",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Account suspended or invalid token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
           }
         },
+        "tags": [
+          "Runs"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -395,14 +649,10 @@
             }
           }
         },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
+        "summary": "Rerun run"
       }
     },
-    "/test-cases": {
+    "/v1/test-cases": {
       "post": {
         "operationId": "CreateTestCase",
         "description": "Create a new test case for a project",
@@ -417,83 +667,11 @@
                 }
               }
             }
-          },
-          "400": {
-            "description": "Validation error or bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Missing or invalid API key",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Account suspended or invalid token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
           }
         },
+        "tags": [
+          "Test Cases"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -504,16 +682,122 @@
             }
           }
         },
-        "security": [
+        "summary": "Create test case"
+      },
+      "get": {
+        "operationId": "ListTestCases",
+        "description": "List test cases for a project",
+        "parameters": [
           {
-            "bearerAuth": []
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ListTestCasesQuery"
+            },
+            "explode": false
           }
-        ]
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListTestCasesResponse"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Test Cases"
+        ],
+        "summary": "List test cases"
       }
     }
   },
+  "security": [
+    {
+      "BearerAuth": []
+    }
+  ],
   "components": {
     "schemas": {
+      "ApplicationBuildCreateRequest": {
+        "type": "object",
+        "required": [
+          "platform",
+          "buildToken"
+        ],
+        "properties": {
+          "platform": {
+            "$ref": "#/components/schemas/MobilePlatform"
+          },
+          "buildToken": {
+            "type": "string"
+          }
+        },
+        "description": "Request body for creating an application build after uploading via presigned URL"
+      },
+      "ApplicationBuildCreateResponse": {
+        "type": "object",
+        "required": [
+          "applicationBuildShortId",
+          "platform",
+          "fileName",
+          "fileSizeBytes"
+        ],
+        "properties": {
+          "applicationBuildShortId": {
+            "$ref": "#/components/schemas/ApplicationBuildShortId"
+          },
+          "platform": {
+            "$ref": "#/components/schemas/MobilePlatform"
+          },
+          "fileName": {
+            "type": "string"
+          },
+          "fileSizeBytes": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "description": "Response with created application build metadata. Use buildShortId in run API environment override."
+      },
+      "ApplicationBuildShortId": {
+        "type": "string",
+        "pattern": "^build(-.+_.+|_.+)$"
+      },
+      "ApplicationBuildUploadUrlRequest": {
+        "type": "object",
+        "required": [
+          "fileName"
+        ],
+        "properties": {
+          "fileName": {
+            "type": "string",
+            "description": "Original file name (e.g. 'my-app.apk'). Preserved in storage for display and file type detection."
+          }
+        },
+        "description": "Request body for getting a presigned upload URL"
+      },
+      "ApplicationBuildUploadUrlResponse": {
+        "type": "object",
+        "required": [
+          "uploadUrl",
+          "buildToken"
+        ],
+        "properties": {
+          "uploadUrl": {
+            "type": "string"
+          },
+          "buildToken": {
+            "type": "string"
+          }
+        },
+        "description": "Presigned upload URL response"
+      },
       "ApplicationEnvironmentOverride": {
         "anyOf": [
           {
@@ -521,8 +805,23 @@
           },
           {
             "$ref": "#/components/schemas/ApplicationEnvironmentOverrideByShortId"
+          },
+          {
+            "$ref": "#/components/schemas/ApplicationEnvironmentOverrideByApplicationBuildShortId"
           }
         ]
+      },
+      "ApplicationEnvironmentOverrideByApplicationBuildShortId": {
+        "type": "object",
+        "required": [
+          "applicationBuildShortId"
+        ],
+        "properties": {
+          "applicationBuildShortId": {
+            "$ref": "#/components/schemas/ApplicationBuildShortId"
+          }
+        },
+        "description": "Use a specific application build (from POST /v1/application/builds). Creates or reuses an environment with this build."
       },
       "ApplicationEnvironmentOverrideByShortId": {
         "type": "object",
@@ -542,9 +841,29 @@
         ],
         "properties": {
           "url": {
-            "type": "string"
+            "type": "string",
+            "format": "uri"
           },
           "name": {
+            "type": "string"
+          }
+        }
+      },
+      "ApplicationItem": {
+        "type": "object",
+        "required": [
+          "shortId",
+          "name",
+          "kind"
+        ],
+        "properties": {
+          "shortId": {
+            "$ref": "#/components/schemas/ApplicationShortId"
+          },
+          "name": {
+            "type": "string"
+          },
+          "kind": {
             "type": "string"
           }
         }
@@ -558,21 +877,323 @@
           "applicationShortId": {
             "$ref": "#/components/schemas/ApplicationShortId"
           },
+          "devicePresetShortId": {
+            "$ref": "#/components/schemas/DevicePresetShortId"
+          },
           "environment": {
             "$ref": "#/components/schemas/ApplicationEnvironmentOverride"
+          }
+        },
+        "description": "Override application, environment, or device preset for a specific run"
+      },
+      "ApplicationOverrideBase": {
+        "type": "object",
+        "required": [
+          "applicationShortId"
+        ],
+        "properties": {
+          "applicationShortId": {
+            "$ref": "#/components/schemas/ApplicationShortId"
           },
           "devicePresetShortId": {
             "$ref": "#/components/schemas/DevicePresetShortId"
           }
         }
       },
+      "ApplicationOverrideWithRequiredEnvironment": {
+        "type": "object",
+        "required": [
+          "applicationShortId",
+          "environment"
+        ],
+        "properties": {
+          "applicationShortId": {
+            "$ref": "#/components/schemas/ApplicationShortId"
+          },
+          "devicePresetShortId": {
+            "$ref": "#/components/schemas/DevicePresetShortId"
+          },
+          "environment": {
+            "$ref": "#/components/schemas/ApplicationEnvironmentOverride"
+          }
+        },
+        "description": "Application override with a required environment"
+      },
       "ApplicationShortId": {
         "type": "string",
         "pattern": "^app(-.+_.+|_.+)$"
       },
+      "BadgeExampleSvgQuery": {
+        "type": "object",
+        "required": [
+          "example"
+        ],
+        "properties": {
+          "example": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StatusBadgeExampleName"
+              }
+            ],
+            "description": "Example preset name. Required."
+          },
+          "label": {
+            "type": "string"
+          },
+          "style": {
+            "$ref": "#/components/schemas/StatusBadgeStyle"
+          },
+          "showDate": {
+            "type": "boolean",
+            "description": "When true, show relative time since last run."
+          },
+          "historyCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "description": "Query parameters for GET /v1/badge-example.svg (deterministic sample badges for docs and demos; no project token)."
+      },
+      "BadgeSvgQuery": {
+        "type": "object",
+        "required": [
+          "token",
+          "testPlanShortId"
+        ],
+        "properties": {
+          "token": {
+            "type": "string",
+            "description": "Status badge secret (project status_badge_token). Required."
+          },
+          "label": {
+            "type": "string"
+          },
+          "style": {
+            "$ref": "#/components/schemas/StatusBadgeStyle"
+          },
+          "showDate": {
+            "type": "boolean",
+            "description": "When true, show relative time since last run."
+          },
+          "historyCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "testPlanShortId": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TestPlanShortId"
+              }
+            ],
+            "description": "Filter runs to this test plan (short id, e.g. pln_my-plan_shortid). Required with `token`."
+          },
+          "createdBy": {
+            "type": "string",
+            "description": "Filter by user id who created the run."
+          },
+          "trigger": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StatusBadgeTriggerFilter"
+              }
+            ],
+            "description": "Filter runs by how they were triggered."
+          }
+        },
+        "description": "Query parameters for GET /v1/badge.svg (live status badge). Token identifies the project; do not use Bearer auth for this operation."
+      },
+      "ChangeReviewRawChanges": {
+        "type": "object",
+        "required": [
+          "changeDescription",
+          "diff"
+        ],
+        "properties": {
+          "changeDescription": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Description of the changes"
+          },
+          "diff": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Git diff content."
+          }
+        },
+        "description": "Structured raw change data for change review mode"
+      },
+      "ChatConversationResponse": {
+        "type": "object",
+        "required": [
+          "shortId",
+          "url",
+          "createdAt",
+          "updatedAt"
+        ],
+        "properties": {
+          "shortId": {
+            "$ref": "#/components/schemas/ChatConversationShortId"
+          },
+          "url": {
+            "type": "string",
+            "description": "Dashboard URL for the conversation."
+          },
+          "title": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "source": {
+            "type": "string",
+            "enum": [
+              "api",
+              "ui",
+              "github",
+              "gitlab",
+              "system"
+            ],
+            "description": "Where the conversation originated. `api` for conversations created via this API, `ui` for the dashboard, `github`/`gitlab` for VCS-triggered chats, and `system` for everything else."
+          },
+          "messages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChatMessageItem"
+            },
+            "description": "Recent messages, newest first. Empty on creation; poll `GET /chat/{chatConversationShortId}` to retrieve."
+          }
+        },
+        "description": "Conversation data with recent messages (newest first)."
+      },
+      "ChatConversationShortId": {
+        "type": "string",
+        "pattern": "^chat(-.+_.+|_.+)$"
+      },
+      "ChatMessageItem": {
+        "type": "object",
+        "required": [
+          "id",
+          "role",
+          "createdAt",
+          "text"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "user",
+              "assistant"
+            ]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "text": {
+            "type": "string",
+            "description": "The plain-text body of the message."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "INITIATED",
+              "PARTIAL",
+              "COMPLETED",
+              "CANCELLED",
+              "FAILED"
+            ],
+            "description": "Lifecycle status of the message. Poll until `COMPLETED` to know the assistant has finished."
+          },
+          "isStreaming": {
+            "type": "boolean",
+            "description": "True while the assistant is still streaming tokens for this message."
+          }
+        },
+        "description": "A chat message. Tool calls and reasoning are not exposed in this version; only the text response is returned."
+      },
+      "ChatRequest": {
+        "type": "object",
+        "required": [
+          "message"
+        ],
+        "properties": {
+          "message": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The message text to send. Example: 'Generate a login flow test for staging'."
+          },
+          "applicationOverrides": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApplicationOverrideWithRequiredEnvironment"
+            },
+            "description": "Optional per-application environment overrides to apply for this conversation."
+          }
+        },
+        "description": "Request body for sending a chat message"
+      },
       "ConfigShortId": {
         "type": "string",
         "pattern": "^cfg(-.+_.+|_.+)$"
+      },
+      "CreateRemoteTunnelRequest": {
+        "type": "object",
+        "required": [
+          "ports"
+        ],
+        "properties": {
+          "ports": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PortMappingRequest"
+            },
+            "description": "One or more local ports to expose via the tunnel"
+          },
+          "public": {
+            "type": "boolean",
+            "description": "If true, the tunnel is publicly accessible without Cloudflare Access authentication"
+          }
+        },
+        "description": "Request body to create a new remote tunnel"
+      },
+      "CreateRemoteTunnelResponse": {
+        "type": "object",
+        "required": [
+          "runnerId",
+          "hostnames",
+          "tunnelToken",
+          "expiresAt"
+        ],
+        "properties": {
+          "runnerId": {
+            "type": "string",
+            "description": "Our identifier for this runner, used in subsequent API calls"
+          },
+          "hostnames": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/HostnameInfo"
+            },
+            "description": "Public hostnames mapped to local ports"
+          },
+          "tunnelToken": {
+            "type": "string",
+            "description": "cloudflared token to start the tunnel daemon"
+          },
+          "expiresAt": {
+            "type": "string",
+            "description": "ISO timestamp when this tunnel will expire"
+          }
+        },
+        "description": "Response after successfully creating a remote tunnel"
       },
       "CreateTestCaseRequest": {
         "type": "object",
@@ -586,7 +1207,8 @@
             "type": "string"
           },
           "goal": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           },
           "expectedResult": {
             "type": "string"
@@ -612,7 +1234,8 @@
           "scenarioShortId": {
             "$ref": "#/components/schemas/ScenarioShortId"
           }
-        }
+        },
+        "description": "Request body for creating a new test case linked to a project"
       },
       "CreateTestCaseResponse": {
         "type": "object",
@@ -629,13 +1252,59 @@
           }
         }
       },
+      "DeleteRemoteTunnelResponse": {
+        "type": "object",
+        "required": [
+          "deleted"
+        ],
+        "properties": {
+          "deleted": {
+            "type": "boolean"
+          }
+        },
+        "description": "Response after deleting a remote tunnel"
+      },
       "DevicePresetShortId": {
         "type": "string",
         "pattern": "^preset(-.+_.+|_.+)$"
       },
+      "EnvironmentItem": {
+        "type": "object",
+        "required": [
+          "shortId",
+          "name",
+          "url",
+          "isProduction"
+        ],
+        "properties": {
+          "shortId": {
+            "$ref": "#/components/schemas/EnvironmentShortId"
+          },
+          "name": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string",
+            "nullable": true
+          },
+          "isProduction": {
+            "type": "boolean"
+          }
+        }
+      },
       "EnvironmentShortId": {
         "type": "string",
         "pattern": "^env(-.+_.+|_.+)$"
+      },
+      "GetChatConversationQuery": {
+        "type": "object",
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "format": "int32",
+            "default": 20
+          }
+        }
       },
       "GetRunQuery": {
         "type": "object",
@@ -700,6 +1369,174 @@
           }
         }
       },
+      "HostnameInfo": {
+        "type": "object",
+        "required": [
+          "localPort",
+          "url"
+        ],
+        "properties": {
+          "localPort": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The local port this hostname maps to"
+          },
+          "url": {
+            "type": "string",
+            "description": "The public HTTPS URL for this port"
+          }
+        },
+        "description": "A single hostname mapping returned by the tunnel"
+      },
+      "ListApplicationEnvironmentsResponse": {
+        "type": "object",
+        "required": [
+          "environments"
+        ],
+        "properties": {
+          "environments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EnvironmentItem"
+            }
+          }
+        }
+      },
+      "ListApplicationsResponse": {
+        "type": "object",
+        "required": [
+          "applications"
+        ],
+        "properties": {
+          "applications": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApplicationItem"
+            }
+          }
+        }
+      },
+      "ListRemoteTunnelsResponse": {
+        "type": "object",
+        "required": [
+          "tunnels"
+        ],
+        "properties": {
+          "tunnels": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RemoteTunnelSummary"
+            }
+          }
+        },
+        "description": "Response for listing active remote tunnels"
+      },
+      "ListTestCaseItem": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "isEnabled",
+          "labels",
+          "classification",
+          "applicationShortId",
+          "applicationName",
+          "goal",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "isEnabled": {
+            "type": "boolean"
+          },
+          "labels": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "classification": {
+            "type": "string"
+          },
+          "applicationShortId": {
+            "$ref": "#/components/schemas/ApplicationShortId"
+          },
+          "applicationName": {
+            "type": "string"
+          },
+          "goal": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string"
+          }
+        }
+      },
+      "ListTestCasesQuery": {
+        "type": "object",
+        "properties": {
+          "applicationShortId": {
+            "$ref": "#/components/schemas/ApplicationShortId"
+          },
+          "labels": {
+            "type": "string"
+          },
+          "isEnabled": {
+            "type": "boolean"
+          },
+          "limit": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "offset": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "ListTestCasesResponse": {
+        "type": "object",
+        "required": [
+          "testCases",
+          "total",
+          "limit",
+          "offset"
+        ],
+        "properties": {
+          "testCases": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ListTestCaseItem"
+            }
+          },
+          "total": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "limit": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "offset": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "MobilePlatform": {
+        "type": "string",
+        "enum": [
+          "ios",
+          "android"
+        ],
+        "description": "Mobile platform for application builds"
+      },
       "NotificationOverride": {
         "type": "object",
         "required": [
@@ -723,7 +1560,8 @@
               "always"
             ]
           }
-        }
+        },
+        "description": "Override notifications for a specific run"
       },
       "OutboundIpsResponse": {
         "type": "object",
@@ -739,6 +1577,96 @@
           }
         }
       },
+      "PortMappingRequest": {
+        "type": "object",
+        "required": [
+          "localPort"
+        ],
+        "properties": {
+          "localPort": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Local port to expose"
+          },
+          "protocol": {
+            "type": "string",
+            "enum": [
+              "http",
+              "https"
+            ],
+            "description": "Protocol for the local service (defaults to http)"
+          },
+          "subdomain": {
+            "type": "string",
+            "description": "Optional subdomain label for this port (e.g. 'api' -> r-{id}-api.quack.run)"
+          }
+        },
+        "description": "A single port mapping to expose through the tunnel"
+      },
+      "RemoteTunnelStatusResponse": {
+        "type": "object",
+        "required": [
+          "status",
+          "connections",
+          "hostnames"
+        ],
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "inactive",
+              "degraded",
+              "healthy"
+            ],
+            "description": "inactive = no connections, degraded = 1-3 connections, healthy = 4+ connections"
+          },
+          "connections": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Number of active Cloudflare edge connections"
+          },
+          "hostnames": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/HostnameInfo"
+            },
+            "description": "Public hostnames for this tunnel"
+          }
+        },
+        "description": "Live health status of a remote tunnel from Cloudflare"
+      },
+      "RemoteTunnelSummary": {
+        "type": "object",
+        "required": [
+          "runnerId",
+          "hostnames",
+          "createdAt",
+          "expiresAt",
+          "isExpired"
+        ],
+        "properties": {
+          "runnerId": {
+            "type": "string"
+          },
+          "hostnames": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/HostnameInfo"
+            }
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "expiresAt": {
+            "type": "string"
+          },
+          "isExpired": {
+            "type": "boolean",
+            "description": "Whether the tunnel is expired (expires_at is in the past)"
+          }
+        },
+        "description": "Summary of an active remote tunnel"
+      },
       "RerunRequest": {
         "type": "object",
         "properties": {
@@ -751,7 +1679,8 @@
               "type": "string"
             }
           }
-        }
+        },
+        "description": "Request body to rerun prior run."
       },
       "RerunResponse": {
         "type": "object",
@@ -848,6 +1777,12 @@
           "testPlanShortId": {
             "$ref": "#/components/schemas/TestPlanShortId"
           },
+          "testCaseIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "applications": {
             "type": "array",
             "items": {
@@ -860,7 +1795,8 @@
               "$ref": "#/components/schemas/NotificationOverride"
             }
           }
-        }
+        },
+        "description": "Request body for triggering a test run. Supports GitHub trigger fields and application overrides."
       },
       "RunResponse": {
         "type": "object",
@@ -929,6 +1865,122 @@
         "type": "string",
         "pattern": "^scenario(-.+_.+|_.+)$"
       },
+      "StartChangeReviewFromPrRequest": {
+        "type": "object",
+        "required": [
+          "mode",
+          "prUrl",
+          "vcsProviderId",
+          "applicationOverrides"
+        ],
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": [
+              "pr"
+            ]
+          },
+          "prUrl": {
+            "type": "string",
+            "format": "uri"
+          },
+          "vcsProviderId": {
+            "$ref": "#/components/schemas/VcsProviderId"
+          },
+          "applicationOverrides": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApplicationOverrideWithRequiredEnvironment"
+            }
+          },
+          "context": {
+            "type": "string"
+          }
+        },
+        "description": "Start a change review chat using a pull request URL"
+      },
+      "StartChangeReviewFromRawChangesRequest": {
+        "type": "object",
+        "required": [
+          "mode",
+          "changes",
+          "applicationOverrides"
+        ],
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": [
+              "rawChanges"
+            ]
+          },
+          "changes": {
+            "$ref": "#/components/schemas/ChangeReviewRawChanges"
+          },
+          "applicationOverrides": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApplicationOverrideWithRequiredEnvironment"
+            }
+          },
+          "context": {
+            "type": "string"
+          }
+        },
+        "description": "Start a change review chat using raw change data"
+      },
+      "StartChangeReviewRequest": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/StartChangeReviewFromPrRequest"
+          },
+          {
+            "$ref": "#/components/schemas/StartChangeReviewFromRawChangesRequest"
+          }
+        ],
+        "description": "Request body for starting a change review chat"
+      },
+      "StatusBadgeExampleName": {
+        "type": "string",
+        "enum": [
+          "failing",
+          "passing",
+          "pending",
+          "running",
+          "rainbow",
+          "partial",
+          "error",
+          "skipped",
+          "cancelled",
+          "mixed",
+          "trend-improving",
+          "trend-declining",
+          "trend-fluctuating",
+          "trend-stable",
+          "zero-tests"
+        ],
+        "description": "Named presets for GET /v1/badge-example.svg (deterministic sample SVGs)."
+      },
+      "StatusBadgeStyle": {
+        "type": "string",
+        "enum": [
+          "minimal",
+          "standard",
+          "detailed",
+          "trend"
+        ],
+        "description": "Display style of the status badge."
+      },
+      "StatusBadgeTriggerFilter": {
+        "type": "string",
+        "enum": [
+          "ANY",
+          "MANUAL",
+          "SCHEDULE",
+          "API",
+          "GITHUB"
+        ],
+        "description": "Permitted values for filtering a status badge by run trigger. Omit the parameter to include all triggers; use ANY for the same behavior explicitly."
+      },
       "TestCase": {
         "type": "object",
         "required": [
@@ -966,19 +2018,26 @@
       "TestPlanShortId": {
         "type": "string",
         "pattern": "^pln(-.+_.+|_.+)$"
+      },
+      "VcsProviderId": {
+        "type": "string",
+        "enum": [
+          "github",
+          "gitlab"
+        ],
+        "description": "Supported VCS providers for pull request URL review mode"
       }
     },
     "securitySchemes": {
-      "bearerAuth": {
+      "BearerAuth": {
         "type": "http",
-        "scheme": "bearer",
-        "description": "Project API token from Settings > Integrations > API. The token is scoped to a specific project."
+        "scheme": "Bearer"
       }
     }
   },
   "servers": [
     {
-      "url": "https://api.qa.tech/v1",
+      "url": "https://api.qa.tech",
       "description": "Production",
       "variables": {}
     }

--- a/api-reference/application-builds.mdx
+++ b/api-reference/application-builds.mdx
@@ -17,8 +17,19 @@ The Application Builds API enables you to upload mobile app builds (APK/IPA file
 - **Version management** – Track and test different build versions
 
 <Note>
-  For mobile app testing concepts, see [Mobile App Testing](/test-features/mobile-app-testing).
+  This API is for **mobile applications** (iOS and Android) only. For web applications, use environment URLs directly in the [Start Run API](/api-reference/start-run) or [Chat API](/api-reference/chat).
 </Note>
+
+## Supported File Types
+
+| Platform | File Types |
+| -------- | ---------- |
+| Android  | `.apk`, `.aab` |
+| iOS      | `.ipa` |
+
+<Tip>
+  For mobile app testing concepts and setup, see [Mobile App Testing](/test-features/mobile-app-testing).
+</Tip>
 
 ## Authentication
 

--- a/api-reference/application-builds.mdx
+++ b/api-reference/application-builds.mdx
@@ -1,0 +1,280 @@
+---
+title: Application Builds API
+description: 'Upload and manage mobile app builds for testing'
+icon: 'mobile'
+---
+
+The Application Builds API enables you to upload mobile app builds (APK/IPA files) for testing with QA.tech. Use these endpoints to integrate mobile app build uploads into your CI/CD pipelines and automation workflows.
+
+- **Base URL**: `https://api.qa.tech/v1`
+- **Authentication**: Bearer token (project API token)
+- **Content-Type**: `application/json`
+
+## When to Use This API
+
+- **CI/CD integration** – Automatically upload builds after successful compilation
+- **Mobile app testing** – Upload iOS and Android builds for automated testing
+- **Version management** – Track and test different build versions
+
+<Note>
+  For mobile app testing concepts, see [Mobile App Testing](/test-features/mobile-app-testing).
+</Note>
+
+## Authentication
+
+Include your project's API token in the `Authorization` header:
+
+```
+Authorization: Bearer YOUR_API_TOKEN
+```
+
+Find your API token in the QA.tech dashboard: **Settings → Integrations → API**.
+
+## Upload Workflow
+
+Uploading a build is a two-step process:
+
+1. **Get upload URL** – Request a presigned URL to upload the file directly to storage
+2. **Create build record** – Register the uploaded file as a build in QA.tech
+
+This two-step process allows efficient direct uploads to cloud storage without passing the file through the API server.
+
+## Get Upload URL
+
+Request a presigned URL to upload a build file.
+
+**Endpoint**: `POST /applications/{applicationShortId}/builds/upload-url`
+
+### Path Parameters
+
+| Parameter            | Type   | Required | Description                              |
+| -------------------- | ------ | -------- | ---------------------------------------- |
+| `applicationShortId` | string | Yes      | Application short ID (e.g. `app_gXeBl2`) |
+
+### Request Body
+
+| Field      | Type   | Required | Description                                                    |
+| ---------- | ------ | -------- | -------------------------------------------------------------- |
+| `fileName` | string | Yes      | Original file name (e.g. `my-app.apk`). Used for display and file type detection. |
+
+### Response (200)
+
+```json
+{
+  "uploadUrl": "https://storage.example.com/presigned-upload-url?signature=...",
+  "buildToken": "tok_abc123xyz789"
+}
+```
+
+### Response Fields
+
+| Field       | Type   | Description                                        |
+| ----------- | ------ | -------------------------------------------------- |
+| `uploadUrl` | string | Presigned URL to PUT the file                      |
+| `buildToken`| string | Token to use when creating the build record        |
+
+### Example
+
+```bash
+curl -X POST "https://api.qa.tech/v1/applications/app_gXeBl2/builds/upload-url" \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "fileName": "my-app-v1.2.3.apk"
+  }'
+```
+
+## Upload the File
+
+After obtaining the presigned URL, upload your file directly to storage using a PUT request:
+
+```bash
+curl -X PUT "$UPLOAD_URL" \
+  --upload-file ./my-app-v1.2.3.apk \
+  -H "Content-Type: application/octet-stream"
+```
+
+<Warning>
+  The presigned URL is temporary and expires quickly. Upload the file immediately after requesting the URL.
+</Warning>
+
+## Create Application Build
+
+After uploading the file, create a build record to register it in QA.tech.
+
+**Endpoint**: `POST /applications/{applicationShortId}/builds`
+
+### Path Parameters
+
+| Parameter            | Type   | Required | Description                              |
+| -------------------- | ------ | -------- | ---------------------------------------- |
+| `applicationShortId` | string | Yes      | Application short ID (e.g. `app_gXeBl2`) |
+
+### Request Body
+
+| Field        | Type   | Required | Description                                  |
+| ------------ | ------ | -------- | -------------------------------------------- |
+| `platform`   | string | Yes      | Mobile platform: `"ios"` or `"android"`      |
+| `buildToken` | string | Yes      | Token from the upload-url response           |
+
+### Response (200)
+
+```json
+{
+  "applicationBuildShortId": "build_abc123",
+  "platform": "android",
+  "fileName": "my-app-v1.2.3.apk",
+  "fileSizeBytes": 52428800
+}
+```
+
+### Response Fields
+
+| Field                     | Type    | Description                                      |
+| ------------------------- | ------- | ------------------------------------------------ |
+| `applicationBuildShortId` | string  | Build short ID to use in run API (e.g. `build_abc123`) |
+| `platform`                | string  | `"ios"` or `"android"`                           |
+| `fileName`                | string  | Original file name                               |
+| `fileSizeBytes`           | integer | File size in bytes                               |
+
+### Example
+
+```bash
+curl -X POST "https://api.qa.tech/v1/applications/app_gXeBl2/builds" \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "platform": "android",
+    "buildToken": "tok_abc123xyz789"
+  }'
+```
+
+## Using Builds in Test Runs
+
+After creating a build, use the `applicationBuildShortId` in the [Start Run API](/api-reference/start-run) to test against that specific build:
+
+```bash
+curl -X POST "https://api.qa.tech/v1/run" \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "testPlanShortId": "pln_abc123",
+    "applications": [
+      {
+        "applicationShortId": "app_gXeBl2",
+        "environment": {
+          "applicationBuildShortId": "build_abc123"
+        }
+      }
+    ]
+  }'
+```
+
+## Complete Workflow Example
+
+Here's a complete example of uploading a build and running tests against it:
+
+```bash
+#!/bin/bash
+
+APP_ID="app_gXeBl2"
+BUILD_FILE="./app/build/outputs/apk/release/app-release.apk"
+FILE_NAME=$(basename "$BUILD_FILE")
+
+# 1. Get the upload URL
+echo "Requesting upload URL..."
+UPLOAD_RESPONSE=$(curl -s -X POST "https://api.qa.tech/v1/applications/$APP_ID/builds/upload-url" \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"fileName\": \"$FILE_NAME\"}")
+
+UPLOAD_URL=$(echo "$UPLOAD_RESPONSE" | jq -r '.uploadUrl')
+BUILD_TOKEN=$(echo "$UPLOAD_RESPONSE" | jq -r '.buildToken')
+
+# 2. Upload the file
+echo "Uploading build file..."
+curl -X PUT "$UPLOAD_URL" \
+  --upload-file "$BUILD_FILE" \
+  -H "Content-Type: application/octet-stream"
+
+# 3. Create the build record
+echo "Creating build record..."
+BUILD_RESPONSE=$(curl -s -X POST "https://api.qa.tech/v1/applications/$APP_ID/builds" \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"platform\": \"android\",
+    \"buildToken\": \"$BUILD_TOKEN\"
+  }")
+
+BUILD_SHORT_ID=$(echo "$BUILD_RESPONSE" | jq -r '.applicationBuildShortId')
+echo "Build created: $BUILD_SHORT_ID"
+
+# 4. Start a test run with this build
+echo "Starting test run..."
+RUN_RESPONSE=$(curl -s -X POST "https://api.qa.tech/v1/run" \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"testPlanShortId\": \"pln_abc123\",
+    \"applications\": [{
+      \"applicationShortId\": \"$APP_ID\",
+      \"environment\": {
+        \"applicationBuildShortId\": \"$BUILD_SHORT_ID\"
+      }
+    }]
+  }")
+
+RUN_URL=$(echo "$RUN_RESPONSE" | jq -r '.run.url')
+echo "Test run started: $RUN_URL"
+```
+
+## CI/CD Integration
+
+### GitHub Actions Example
+
+```yaml
+- name: Upload build to QA.tech
+  env:
+    QATECH_API_TOKEN: ${{ secrets.QATECH_API_TOKEN }}
+  run: |
+    # Get upload URL
+    UPLOAD_RESPONSE=$(curl -s -X POST "https://api.qa.tech/v1/applications/app_gXeBl2/builds/upload-url" \
+      -H "Authorization: Bearer $QATECH_API_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d '{"fileName": "app-release.apk"}')
+    
+    UPLOAD_URL=$(echo "$UPLOAD_RESPONSE" | jq -r '.uploadUrl')
+    BUILD_TOKEN=$(echo "$UPLOAD_RESPONSE" | jq -r '.buildToken')
+    
+    # Upload file
+    curl -X PUT "$UPLOAD_URL" \
+      --upload-file ./app/build/outputs/apk/release/app-release.apk
+    
+    # Create build record
+    BUILD_RESPONSE=$(curl -s -X POST "https://api.qa.tech/v1/applications/app_gXeBl2/builds" \
+      -H "Authorization: Bearer $QATECH_API_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d "{\"platform\": \"android\", \"buildToken\": \"$BUILD_TOKEN\"}")
+    
+    echo "BUILD_SHORT_ID=$(echo $BUILD_RESPONSE | jq -r '.applicationBuildShortId')" >> $GITHUB_ENV
+```
+
+## Error Responses
+
+| Status  | Description                                       |
+| ------- | ------------------------------------------------- |
+| **400** | Validation error, invalid file type, or malformed request |
+| **401** | Missing or invalid API key                        |
+| **403** | Invalid token or organization suspended           |
+| **404** | Application or project not found                  |
+| **500** | Server error                                      |
+
+Error responses include a body: `{ "message": "Error description" }`.
+
+## Related
+
+- [Mobile App Testing](/test-features/mobile-app-testing) – Mobile testing concepts
+- [Start Run API](/api-reference/start-run) – Run tests against uploaded builds
+- [Applications API](/api-reference/applications) – List applications
+- [API Introduction](/api-reference/introduction) – Authentication and ID reference

--- a/api-reference/applications.mdx
+++ b/api-reference/applications.mdx
@@ -1,0 +1,199 @@
+---
+title: Applications API
+description: 'List applications and their environments programmatically'
+icon: 'browser'
+---
+
+Retrieve applications and their environments from your project. Use these endpoints to discover application and environment short IDs for use with other API endpoints like [Start Run](/api-reference/start-run) and [Chat](/api-reference/chat).
+
+- **Base URL**: `https://api.qa.tech/v1`
+- **Authentication**: Bearer token (project API token)
+
+## Authentication
+
+Include your project's API token in the `Authorization` header:
+
+```
+Authorization: Bearer YOUR_API_TOKEN
+```
+
+Find your API token in the QA.tech dashboard: **Settings → Integrations → API**.
+
+## List Applications
+
+Retrieve all applications in your project.
+
+**Endpoint**: `GET /applications`
+
+### Response (200)
+
+```json
+{
+  "applications": [
+    {
+      "shortId": "app_gXeBl2",
+      "name": "Main Web App",
+      "kind": "web"
+    },
+    {
+      "shortId": "app_mK9pR4",
+      "name": "Mobile App",
+      "kind": "ios"
+    },
+    {
+      "shortId": "app_dF7nT1",
+      "name": "Android App",
+      "kind": "android"
+    }
+  ]
+}
+```
+
+### Response Fields
+
+| Field          | Type   | Description                                  |
+| -------------- | ------ | -------------------------------------------- |
+| `applications` | array  | Array of application objects                 |
+
+### Application Fields
+
+| Field     | Type   | Description                                      |
+| --------- | ------ | ------------------------------------------------ |
+| `shortId` | string | Application short ID (e.g. `app_gXeBl2`)         |
+| `name`    | string | Application display name                         |
+| `kind`    | string | Application type: `web`, `ios`, or `android`     |
+
+### Example
+
+```bash
+curl "https://api.qa.tech/v1/applications" \
+  -H "Authorization: Bearer YOUR_API_TOKEN"
+```
+
+## List Environments
+
+Retrieve all environments for a specific application.
+
+**Endpoint**: `GET /applications/{applicationShortId}/environments`
+
+### Path Parameters
+
+| Parameter            | Type   | Required | Description                              |
+| -------------------- | ------ | -------- | ---------------------------------------- |
+| `applicationShortId` | string | Yes      | Application short ID (e.g. `app_gXeBl2`) |
+
+### Response (200)
+
+```json
+{
+  "environments": [
+    {
+      "shortId": "env_aB3xY9",
+      "name": "Production",
+      "url": "https://app.example.com",
+      "isProduction": true
+    },
+    {
+      "shortId": "env_cD5zW2",
+      "name": "Staging",
+      "url": "https://staging.example.com",
+      "isProduction": false
+    },
+    {
+      "shortId": "env_eF7vU4",
+      "name": "Development",
+      "url": "https://dev.example.com",
+      "isProduction": false
+    }
+  ]
+}
+```
+
+### Response Fields
+
+| Field          | Type   | Description                       |
+| -------------- | ------ | --------------------------------- |
+| `environments` | array  | Array of environment objects      |
+
+### Environment Fields
+
+| Field          | Type           | Description                                   |
+| -------------- | -------------- | --------------------------------------------- |
+| `shortId`      | string         | Environment short ID (e.g. `env_aB3xY9`)      |
+| `name`         | string         | Environment display name                      |
+| `url`          | string \| null | Base URL for the environment                  |
+| `isProduction` | boolean        | Whether this is the production environment    |
+
+### Example
+
+```bash
+curl "https://api.qa.tech/v1/applications/app_gXeBl2/environments" \
+  -H "Authorization: Bearer YOUR_API_TOKEN"
+```
+
+## Use Cases
+
+### Discovering IDs for API Calls
+
+Use these endpoints to programmatically discover application and environment IDs:
+
+```bash
+# Get all applications
+APPS=$(curl -s "https://api.qa.tech/v1/applications" \
+  -H "Authorization: Bearer YOUR_API_TOKEN")
+
+# Extract the first application's short ID
+APP_ID=$(echo "$APPS" | jq -r '.applications[0].shortId')
+
+# Get environments for that application
+ENVS=$(curl -s "https://api.qa.tech/v1/applications/$APP_ID/environments" \
+  -H "Authorization: Bearer YOUR_API_TOKEN")
+
+# Find the staging environment
+STAGING_ENV=$(echo "$ENVS" | jq -r '.environments[] | select(.name == "Staging") | .shortId')
+
+echo "Application: $APP_ID"
+echo "Staging Environment: $STAGING_ENV"
+```
+
+### Dynamic Environment Selection in CI/CD
+
+```bash
+# In your CI/CD pipeline
+APP_ID="app_gXeBl2"
+
+# Find the non-production environment to test against
+ENV_ID=$(curl -s "https://api.qa.tech/v1/applications/$APP_ID/environments" \
+  -H "Authorization: Bearer $QATECH_API_TOKEN" \
+  | jq -r '.environments[] | select(.isProduction == false) | .shortId' | head -1)
+
+# Start a test run with the discovered environment
+curl -X POST "https://api.qa.tech/v1/run" \
+  -H "Authorization: Bearer $QATECH_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"testPlanShortId\": \"pln_abc123\",
+    \"applications\": [{
+      \"applicationShortId\": \"$APP_ID\",
+      \"environment\": { \"shortId\": \"$ENV_ID\" }
+    }]
+  }"
+```
+
+## Error Responses
+
+| Status  | Description                                |
+| ------- | ------------------------------------------ |
+| **401** | Missing or invalid API key                 |
+| **403** | Invalid token or organization suspended    |
+| **404** | Project or application not found           |
+| **500** | Server error                               |
+
+Error responses include a body: `{ "message": "Error description" }`.
+
+## Related
+
+- [Start Run API](/api-reference/start-run) – Use application/environment IDs to run tests
+- [Chat API](/api-reference/chat) – Use application overrides in chat conversations
+- [Applications and Environments](/core-concepts/applications-and-environments) – Learn about the application model
+- [API Introduction](/api-reference/introduction) – Authentication and ID reference

--- a/api-reference/applications.mdx
+++ b/api-reference/applications.mdx
@@ -9,6 +9,10 @@ Retrieve applications and their environments from your project. Use these endpoi
 - **Base URL**: `https://api.qa.tech/v1`
 - **Authentication**: Bearer token (project API token)
 
+<Tip>
+  You can also find Application and Environment Short IDs in the QA.tech dashboard: **Settings → Applications**. The short IDs (e.g. `app_gXeBl2`, `env_aB3xY9`) are displayed in the UI and can be copied using the three-dot menu (⋮).
+</Tip>
+
 ## Authentication
 
 Include your project's API token in the `Authorization` header:

--- a/api-reference/chat.mdx
+++ b/api-reference/chat.mdx
@@ -1,0 +1,328 @@
+---
+title: Chat API
+description: 'Interact with the QA.tech AI Chat Assistant programmatically'
+icon: 'message-bot'
+---
+
+The Chat API enables programmatic interaction with QA.tech's AI Chat Assistant. Create conversations, send messages, start change reviews, and poll for responses—all via REST API. This is ideal for integrating QA.tech's AI capabilities into your automation workflows, project management systems, or custom tooling.
+
+- **Base URL**: `https://api.qa.tech/v1`
+- **Authentication**: Bearer token (project API token)
+- **Content-Type**: `application/json`
+
+## When to Use This API
+
+- **Automated test creation** – Send context from your system to create tests without opening the QA.tech UI
+- **PR/Change reviews** – Automatically trigger AI-powered change reviews from CI/CD pipelines
+- **Custom integrations** – Build buttons or workflows in your project management tools that interact with QA.tech Chat
+- **AI-assisted QA workflows** – Let your automation systems communicate with QA.tech's AI assistant
+
+## Authentication
+
+All Chat API endpoints require Bearer token authentication:
+
+```
+Authorization: Bearer YOUR_API_TOKEN
+```
+
+Find your API token in the QA.tech dashboard: **Settings → Integrations → API**.
+
+## Create Chat Conversation
+
+Create a new chat conversation and send the first message. Processing is asynchronous—poll the [Get Conversation](#get-conversation) endpoint until the assistant's response is complete.
+
+**Endpoint**: `POST /chat`
+
+### Request Body
+
+| Field                  | Type   | Required | Description                                                              |
+| ---------------------- | ------ | -------- | ------------------------------------------------------------------------ |
+| `message`              | string | Yes      | The message text to send (min 1 character)                               |
+| `applicationOverrides` | array  | No       | Per-application environment overrides for this conversation (see below) |
+
+### Application Overrides
+
+Each object in the `applicationOverrides` array:
+
+| Field                  | Type   | Required | Description                                      |
+| ---------------------- | ------ | -------- | ------------------------------------------------ |
+| `applicationShortId`   | string | Yes      | Application short ID (e.g. `app_gXeBl2`)         |
+| `devicePresetShortId`  | string | No       | Device preset short ID (e.g. `preset_abc123`)    |
+| `environment`          | object | Yes      | Environment override (see below)                 |
+
+**Environment override** – use one of:
+
+- **By URL**: `{ "url": "https://...", "name": "Optional name" }`
+- **By short ID**: `{ "shortId": "env_aB3xY9" }`
+- **By build**: `{ "applicationBuildShortId": "build_abc123" }` (for mobile apps)
+
+### Response (202 Accepted)
+
+```json
+{
+  "shortId": "chat_abc123",
+  "url": "https://app.qa.tech/p/your-project/chat/chat_abc123",
+  "title": null,
+  "createdAt": "2026-05-04T10:30:00.000Z",
+  "updatedAt": "2026-05-04T10:30:00.000Z",
+  "source": "api",
+  "messages": []
+}
+```
+
+The response returns immediately with 202. The `messages` array is empty on creation. Poll [Get Conversation](#get-conversation) to retrieve the assistant's reply.
+
+### Example
+
+```bash
+curl -X POST https://api.qa.tech/v1/chat \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "message": "Generate a login flow test for our staging environment"
+  }'
+```
+
+### Example with Environment Override
+
+```bash
+curl -X POST https://api.qa.tech/v1/chat \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "message": "Create a test for the checkout flow",
+    "applicationOverrides": [
+      {
+        "applicationShortId": "app_gXeBl2",
+        "environment": {
+          "url": "https://pr-123.preview.example.com",
+          "name": "PR-123 Preview"
+        }
+      }
+    ]
+  }'
+```
+
+## Start Change Review
+
+Create a conversation that initiates an AI-powered change review. Supports two modes: reviewing a pull request URL or raw code changes.
+
+**Endpoint**: `POST /chat/change-review`
+
+### Request Body (PR Mode)
+
+| Field                  | Type   | Required | Description                                              |
+| ---------------------- | ------ | -------- | -------------------------------------------------------- |
+| `mode`                 | string | Yes      | Must be `"pr"`                                           |
+| `prUrl`                | string | Yes      | Pull request URL to review                               |
+| `vcsProviderId`        | string | Yes      | VCS provider: `"github"` or `"gitlab"`                   |
+| `applicationOverrides` | array  | Yes      | Application environment overrides (see above)            |
+| `context`              | string | No       | Additional context to help the AI understand the changes |
+
+### Request Body (Raw Changes Mode)
+
+| Field                        | Type   | Required | Description                                              |
+| ---------------------------- | ------ | -------- | -------------------------------------------------------- |
+| `mode`                       | string | Yes      | Must be `"rawChanges"`                                   |
+| `changes.changeDescription`  | string | Yes      | Description of the changes (min 1 character)             |
+| `changes.diff`               | string | Yes      | Git diff content (min 1 character)                       |
+| `applicationOverrides`       | array  | Yes      | Application environment overrides (see above)            |
+| `context`                    | string | No       | Additional context to help the AI understand the changes |
+
+### Response (202 Accepted)
+
+Same format as [Create Chat Conversation](#create-chat-conversation).
+
+### Example: Review a Pull Request
+
+```bash
+curl -X POST https://api.qa.tech/v1/chat/change-review \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "mode": "pr",
+    "prUrl": "https://github.com/your-org/your-repo/pull/123",
+    "vcsProviderId": "github",
+    "applicationOverrides": [
+      {
+        "applicationShortId": "app_gXeBl2",
+        "environment": { "shortId": "env_aB3xY9" }
+      }
+    ],
+    "context": "This PR updates the payment processing flow"
+  }'
+```
+
+### Example: Review Raw Changes
+
+```bash
+curl -X POST https://api.qa.tech/v1/chat/change-review \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "mode": "rawChanges",
+    "changes": {
+      "changeDescription": "Updated login validation to require email format",
+      "diff": "diff --git a/src/auth.js b/src/auth.js\n..."
+    },
+    "applicationOverrides": [
+      {
+        "applicationShortId": "app_gXeBl2",
+        "environment": { "shortId": "env_aB3xY9" }
+      }
+    ]
+  }'
+```
+
+## Send Message to Conversation
+
+Send a follow-up message to an existing conversation. Returns 202 immediately—poll [Get Conversation](#get-conversation) for the assistant's reply.
+
+**Endpoint**: `POST /chat/{chatConversationShortId}`
+
+### Path Parameters
+
+| Parameter                 | Type   | Required | Description                              |
+| ------------------------- | ------ | -------- | ---------------------------------------- |
+| `chatConversationShortId` | string | Yes      | Conversation short ID (e.g. `chat_abc123`) |
+
+### Request Body
+
+Same as [Create Chat Conversation](#create-chat-conversation).
+
+### Response (202 Accepted)
+
+Same format as [Create Chat Conversation](#create-chat-conversation), with existing messages included.
+
+### Example
+
+```bash
+curl -X POST https://api.qa.tech/v1/chat/chat_abc123 \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "message": "Can you also add a test for the forgot password flow?"
+  }'
+```
+
+## Get Conversation
+
+Retrieve conversation metadata and messages. Use this to poll for the assistant's response after sending a message.
+
+**Endpoint**: `GET /chat/{chatConversationShortId}`
+
+### Path Parameters
+
+| Parameter                 | Type   | Required | Description                              |
+| ------------------------- | ------ | -------- | ---------------------------------------- |
+| `chatConversationShortId` | string | Yes      | Conversation short ID (e.g. `chat_abc123`) |
+
+### Query Parameters
+
+| Parameter | Type    | Default | Description                    |
+| --------- | ------- | ------- | ------------------------------ |
+| `limit`   | integer | 20      | Number of messages to return   |
+
+### Response (200 OK)
+
+```json
+{
+  "shortId": "chat_abc123",
+  "url": "https://app.qa.tech/p/your-project/chat/chat_abc123",
+  "title": "Login Flow Test",
+  "createdAt": "2026-05-04T10:30:00.000Z",
+  "updatedAt": "2026-05-04T10:35:00.000Z",
+  "source": "api",
+  "messages": [
+    {
+      "id": "msg_123",
+      "role": "user",
+      "createdAt": "2026-05-04T10:30:00.000Z",
+      "text": "Generate a login flow test for our staging environment",
+      "status": "COMPLETED",
+      "isStreaming": false
+    },
+    {
+      "id": "msg_456",
+      "role": "assistant",
+      "createdAt": "2026-05-04T10:30:05.000Z",
+      "text": "I'll create a login flow test for your staging environment...",
+      "status": "COMPLETED",
+      "isStreaming": false
+    }
+  ]
+}
+```
+
+### Response Fields
+
+| Field       | Type     | Description                                                           |
+| ----------- | -------- | --------------------------------------------------------------------- |
+| `shortId`   | string   | Conversation short ID (e.g. `chat_abc123`)                            |
+| `url`       | string   | Dashboard URL for the conversation                                    |
+| `title`     | string   | Conversation title (may be null initially)                            |
+| `createdAt` | string   | ISO 8601 timestamp                                                    |
+| `updatedAt` | string   | ISO 8601 timestamp                                                    |
+| `source`    | string   | Where the conversation originated: `api`, `ui`, `github`, `gitlab`, `system` |
+| `messages`  | array    | Recent messages, newest first                                         |
+
+### Message Fields
+
+| Field         | Type    | Description                                                       |
+| ------------- | ------- | ----------------------------------------------------------------- |
+| `id`          | string  | Message identifier                                                |
+| `role`        | string  | `"user"` or `"assistant"`                                         |
+| `createdAt`   | string  | ISO 8601 timestamp                                                |
+| `text`        | string  | The message content                                               |
+| `status`      | string  | `INITIATED`, `PARTIAL`, `COMPLETED`, `CANCELLED`, or `FAILED`     |
+| `isStreaming` | boolean | `true` while the assistant is still generating the response       |
+
+### Polling for Completion
+
+To wait for the assistant's response, poll until the most recent `assistant` message has `status: "COMPLETED"`:
+
+```bash
+while true; do
+  RESPONSE=$(curl -s "https://api.qa.tech/v1/chat/chat_abc123" \
+    -H "Authorization: Bearer YOUR_API_TOKEN")
+  
+  STATUS=$(echo "$RESPONSE" | jq -r '.messages[0].status')
+  ROLE=$(echo "$RESPONSE" | jq -r '.messages[0].role')
+  
+  if [[ "$ROLE" == "assistant" && "$STATUS" == "COMPLETED" ]]; then
+    echo "Response complete:"
+    echo "$RESPONSE" | jq '.messages[0].text'
+    break
+  elif [[ "$STATUS" == "FAILED" || "$STATUS" == "CANCELLED" ]]; then
+    echo "Response failed or cancelled"
+    break
+  fi
+  
+  sleep 2
+done
+```
+
+### Example
+
+```bash
+curl "https://api.qa.tech/v1/chat/chat_abc123?limit=50" \
+  -H "Authorization: Bearer YOUR_API_TOKEN"
+```
+
+## Error Responses
+
+| Status  | Description                                        |
+| ------- | -------------------------------------------------- |
+| **400** | Validation error or malformed request body         |
+| **401** | Missing or invalid API key                         |
+| **403** | Invalid token or organization suspended            |
+| **404** | Conversation or project not found                  |
+| **500** | Server error                                       |
+
+Error responses include a body: `{ "message": "Error description" }`.
+
+## Related
+
+- [AI Chat Assistant](/core-concepts/ai-chat-assistant) – Learn about QA.tech's AI assistant
+- [API Introduction](/api-reference/introduction) – Authentication and ID reference
+- [Start Run API](/api-reference/start-run) – Trigger test runs programmatically

--- a/api-reference/chat.mdx
+++ b/api-reference/chat.mdx
@@ -17,6 +17,10 @@ The Chat API enables programmatic interaction with QA.tech's AI Chat Assistant. 
 - **Custom integrations** – Build buttons or workflows in your project management tools that interact with QA.tech Chat
 - **AI-assisted QA workflows** – Let your automation systems communicate with QA.tech's AI assistant
 
+<Tip>
+  For simpler chat interactions, consider using the [CLI chat command](/cli/commands/chat) which handles polling automatically: `qatech chat "Create a login test"`
+</Tip>
+
 ## Authentication
 
 All Chat API endpoints require Bearer token authentication:
@@ -279,7 +283,11 @@ Retrieve conversation metadata and messages. Use this to poll for the assistant'
 
 ### Polling for Completion
 
-To wait for the assistant's response, poll until the most recent `assistant` message has `status: "COMPLETED"`:
+To wait for the assistant's response, poll until the most recent `assistant` message has `status: "COMPLETED"`. We recommend polling every **2-5 seconds**.
+
+<Note>
+  Assistant responses typically complete within 10-60 seconds depending on the complexity of the request. Test creation and execution may take several minutes.
+</Note>
 
 ```bash
 while true; do
@@ -298,7 +306,7 @@ while true; do
     break
   fi
   
-  sleep 2
+  sleep 3  # Poll every 3 seconds
 done
 ```
 

--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -9,11 +9,14 @@ The QA.tech REST API allows you to programmatically control test runs, create te
 ## What Can You Do?
 
 - **Start test runs** programmatically from CI/CD pipelines or scripts
-- **Create test cases** via API for importing tests or generating them dynamically
+- **Create and list test cases** via API for importing tests or generating them dynamically
 - **Check run status** and retrieve test results
 - **Rerun tests** (all or a subset) from a previous run
+- **Chat with AI assistant** to create tests and review changes via API
+- **List applications and environments** for dynamic test configuration
+- **Create remote tunnels** to test local environments
+- **Upload mobile app builds** for iOS and Android testing
 - **Get outbound IPs** for firewall allowlisting
-- **View metrics** and test execution data
 
 ## Quick Start
 
@@ -63,6 +66,8 @@ QA.tech uses **prefixed short IDs** for most API resources. The prefix indicates
 | **Config Short ID**        | `cfg_` + alphanumeric      | Settings → Configs                     | `configShortIds` array                      | `cfg_xyz789`      |
 | **Device Preset Short ID** | `preset_` + alphanumeric   | Settings → Device Presets              | `devicePresetShortId` in applications array | `preset_abc123`   |
 | **Scenario Short ID**      | `scenario_` + alphanumeric | Scenarios                              | `scenarioShortId` in test-cases body        | `scenario_abc123` |
+| **Chat Conversation ID**   | `chat_` + alphanumeric     | Chat API response                      | `chatConversationShortId` in chat endpoints | `chat_abc123`     |
+| **Application Build ID**   | `build_` + alphanumeric    | Build API response                     | `applicationBuildShortId` in environment    | `build_abc123`    |
 
 ### Finding Application and Environment Short IDs
 
@@ -89,6 +94,11 @@ Application and Environment Short IDs are shown in the UI with their `app_` and 
 - **[Get Run Status](/api-reference/run-status)** - Wait for test completion in CI/CD pipelines
 - **[Rerun Tests](/api-reference/rerun)** - Rerun all or failed tests from a previous run
 - **[Create Test Cases](/api-reference/test-cases)** - Create tests via API
+- **[List Test Cases](/api-reference/list-test-cases)** - Retrieve test cases from your project
+- **[Chat API](/api-reference/chat)** - Interact with the AI assistant programmatically
+- **[Applications API](/api-reference/applications)** - List applications and environments
+- **[Remote Tunnels API](/api-reference/remote-tunnels)** - Create tunnels to test local environments
+- **[Application Builds API](/api-reference/application-builds)** - Upload mobile app builds
 - **[Get Outbound IPs](/api-reference/outbound-ips)** - Retrieve IPs for firewall allowlisting
 - **[View OpenAPI Spec](/api-reference/api.json)** - Complete API reference with all endpoints
 

--- a/api-reference/list-test-cases.mdx
+++ b/api-reference/list-test-cases.mdx
@@ -10,6 +10,10 @@ List and filter test cases in your project. Use this endpoint to retrieve test c
 - **Authentication**: Bearer token (project API token)
 - **Base URL**: `https://api.qa.tech/v1`
 
+<Note>
+  The test case `id` (UUID) is used when creating tests with dependencies or running specific test cases via the [Rerun API](/api-reference/rerun). For most run operations, use test plans instead of individual test case IDs.
+</Note>
+
 ## Authentication
 
 Include your project's API token in the `Authorization` header:

--- a/api-reference/list-test-cases.mdx
+++ b/api-reference/list-test-cases.mdx
@@ -1,0 +1,154 @@
+---
+title: List Test Cases API
+description: 'Retrieve test cases from your project programmatically'
+icon: 'list'
+---
+
+List and filter test cases in your project. Use this endpoint to retrieve test cases for reporting, syncing with external systems, or building custom dashboards.
+
+- **Endpoint**: `GET /test-cases`
+- **Authentication**: Bearer token (project API token)
+- **Base URL**: `https://api.qa.tech/v1`
+
+## Authentication
+
+Include your project's API token in the `Authorization` header:
+
+```
+Authorization: Bearer YOUR_API_TOKEN
+```
+
+Find your API token in the QA.tech dashboard: **Settings → Integrations → API**.
+
+## Query Parameters
+
+All parameters are optional. Use them to filter and paginate results:
+
+| Parameter            | Type    | Description                                              |
+| -------------------- | ------- | -------------------------------------------------------- |
+| `applicationShortId` | string  | Filter by application (e.g. `app_gXeBl2`)                |
+| `labels`             | string  | Filter by labels (comma-separated, e.g. `smoke,login`)   |
+| `isEnabled`          | boolean | Filter by enabled status (`true` or `false`)             |
+| `limit`              | integer | Maximum number of results to return                      |
+| `offset`             | integer | Number of results to skip (for pagination)               |
+
+## Response Format
+
+### Success (200)
+
+```json
+{
+  "testCases": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440000",
+      "name": "Login Flow Test",
+      "isEnabled": true,
+      "labels": ["smoke", "auth"],
+      "classification": "functional",
+      "applicationShortId": "app_gXeBl2",
+      "applicationName": "Main Web App",
+      "goal": "Verify users can log in with valid credentials",
+      "createdAt": "2026-01-15T10:30:00.000Z"
+    },
+    {
+      "id": "661f9500-f3a2-52e5-b827-557766550111",
+      "name": "Checkout Process",
+      "isEnabled": true,
+      "labels": ["critical", "e2e"],
+      "classification": "functional",
+      "applicationShortId": "app_gXeBl2",
+      "applicationName": "Main Web App",
+      "goal": "Complete a purchase from cart to confirmation",
+      "createdAt": "2026-02-20T14:15:00.000Z"
+    }
+  ],
+  "total": 42,
+  "limit": 20,
+  "offset": 0
+}
+```
+
+### Response Fields
+
+| Field       | Type    | Description                          |
+| ----------- | ------- | ------------------------------------ |
+| `testCases` | array   | Array of test case objects           |
+| `total`     | integer | Total number of matching test cases  |
+| `limit`     | integer | Applied limit value                  |
+| `offset`    | integer | Applied offset value                 |
+
+### Test Case Fields
+
+| Field                | Type           | Description                                      |
+| -------------------- | -------------- | ------------------------------------------------ |
+| `id`                 | string (UUID)  | Test case identifier                             |
+| `name`               | string         | Test case name                                   |
+| `isEnabled`          | boolean        | Whether the test is enabled in test plans        |
+| `labels`             | array          | Array of label strings                           |
+| `classification`     | string         | Test classification (e.g. `functional`)          |
+| `applicationShortId` | string         | Associated application short ID                  |
+| `applicationName`    | string         | Associated application name                      |
+| `goal`               | string \| null | Test goal/objective                              |
+| `createdAt`          | string         | ISO 8601 creation timestamp                      |
+
+## Example Requests
+
+### List All Test Cases
+
+```bash
+curl "https://api.qa.tech/v1/test-cases" \
+  -H "Authorization: Bearer YOUR_API_TOKEN"
+```
+
+### Filter by Application
+
+```bash
+curl "https://api.qa.tech/v1/test-cases?applicationShortId=app_gXeBl2" \
+  -H "Authorization: Bearer YOUR_API_TOKEN"
+```
+
+### Filter by Labels
+
+```bash
+curl "https://api.qa.tech/v1/test-cases?labels=smoke,critical" \
+  -H "Authorization: Bearer YOUR_API_TOKEN"
+```
+
+### List Only Enabled Tests
+
+```bash
+curl "https://api.qa.tech/v1/test-cases?isEnabled=true" \
+  -H "Authorization: Bearer YOUR_API_TOKEN"
+```
+
+### Paginated Request
+
+```bash
+curl "https://api.qa.tech/v1/test-cases?limit=10&offset=20" \
+  -H "Authorization: Bearer YOUR_API_TOKEN"
+```
+
+### Combined Filters
+
+```bash
+curl "https://api.qa.tech/v1/test-cases?applicationShortId=app_gXeBl2&isEnabled=true&labels=smoke&limit=50" \
+  -H "Authorization: Bearer YOUR_API_TOKEN"
+```
+
+## Error Responses
+
+| Status  | Description                                |
+| ------- | ------------------------------------------ |
+| **400** | Invalid query parameters                   |
+| **401** | Missing or invalid API key                 |
+| **403** | Invalid token or organization suspended    |
+| **404** | Project not found                          |
+| **500** | Server error                               |
+
+Error responses include a body: `{ "message": "Error description" }`.
+
+## Related
+
+- [Create Test Case API](/api-reference/test-cases) – Create test cases programmatically
+- [Start Run API](/api-reference/start-run) – Trigger test runs
+- [API Introduction](/api-reference/introduction) – Authentication and ID reference

--- a/api-reference/remote-tunnels.mdx
+++ b/api-reference/remote-tunnels.mdx
@@ -10,6 +10,30 @@ The Remote Tunnels API enables you to programmatically create secure tunnels tha
 - **Authentication**: Bearer token (project API token)
 - **Content-Type**: `application/json`
 
+## Prerequisites
+
+Before using the Remote Tunnels API, you need:
+
+1. **cloudflared** – Cloudflare's tunnel client must be installed on your machine or CI runner
+   ```bash
+   # macOS
+   brew install cloudflared
+   
+   # Linux (Debian/Ubuntu)
+   curl -L --output cloudflared.deb https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb
+   sudo dpkg -i cloudflared.deb
+   
+   # See https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/install-and-setup/installation/
+   ```
+
+2. **Your application running locally** – The tunnel exposes local ports, so your app must be running
+
+## Tunnel Expiration
+
+<Warning>
+  Tunnels expire **12 hours** after creation. The `expiresAt` field in the response indicates when the tunnel will be automatically torn down. For long-running development, you'll need to create a new tunnel when the current one expires.
+</Warning>
+
 ## When to Use Remote Tunnels
 
 - **Local development testing** – Test your local environment without deploying
@@ -123,7 +147,11 @@ After creating a tunnel, start the cloudflared daemon with the returned token:
 cloudflared tunnel run --token YOUR_TUNNEL_TOKEN
 ```
 
-The tunnel will remain active as long as cloudflared is running.
+The tunnel will remain active as long as cloudflared is running and has not expired (12-hour maximum lifetime).
+
+<Tip>
+  For simpler tunnel management, consider using the [CLI tunnel command](/cli/commands/tunnel) which handles cloudflared automatically: `qatech tunnel start --port 3000`
+</Tip>
 
 ## List Remote Tunnels
 

--- a/api-reference/remote-tunnels.mdx
+++ b/api-reference/remote-tunnels.mdx
@@ -1,0 +1,323 @@
+---
+title: Remote Tunnels API
+description: 'Create and manage secure tunnels to expose local environments'
+icon: 'tunnel'
+---
+
+The Remote Tunnels API enables you to programmatically create secure tunnels that expose local ports via Cloudflare. This allows QA.tech to access locally-running applications for testing without deploying them to a public server.
+
+- **Base URL**: `https://api.qa.tech/v1`
+- **Authentication**: Bearer token (project API token)
+- **Content-Type**: `application/json`
+
+## When to Use Remote Tunnels
+
+- **Local development testing** – Test your local environment without deploying
+- **CI/CD pipelines** – Expose ephemeral test servers during build processes
+- **Preview environments** – Create temporary public URLs for testing
+- **Firewall-protected environments** – Access applications behind corporate firewalls
+
+<Note>
+  For CLI-based tunnel management, see the [tunnel command](/cli/commands/tunnel) documentation. The CLI provides a simpler interface for common tunnel operations.
+</Note>
+
+## Authentication
+
+Include your project's API token in the `Authorization` header:
+
+```
+Authorization: Bearer YOUR_API_TOKEN
+```
+
+Find your API token in the QA.tech dashboard: **Settings → Integrations → API**.
+
+## Create Remote Tunnel
+
+Create a new tunnel that exposes one or more local ports via Cloudflare. Returns a `tunnelToken` to start the cloudflared daemon.
+
+**Endpoint**: `POST /remote-tunnels`
+
+### Request Body
+
+| Field    | Type    | Required | Description                                                    |
+| -------- | ------- | -------- | -------------------------------------------------------------- |
+| `ports`  | array   | Yes      | Array of port mappings to expose (see below)                   |
+| `public` | boolean | No       | If `true`, tunnel is publicly accessible without auth          |
+
+### Port Mapping Fields
+
+| Field       | Type    | Required | Description                                                         |
+| ----------- | ------- | -------- | ------------------------------------------------------------------- |
+| `localPort` | integer | Yes      | Local port number to expose                                         |
+| `protocol`  | string  | No       | Protocol: `"http"` (default) or `"https"`                           |
+| `subdomain` | string  | No       | Optional subdomain label (e.g. `"api"` → `r-{id}-api.quack.run`)    |
+
+### Response (200)
+
+```json
+{
+  "runnerId": "tunnel_abc123",
+  "hostnames": [
+    {
+      "localPort": 3000,
+      "url": "https://r-tunnel_abc123-app.quack.run"
+    },
+    {
+      "localPort": 8080,
+      "url": "https://r-tunnel_abc123-api.quack.run"
+    }
+  ],
+  "tunnelToken": "eyJhIjoiYWJjMTIzLi4uIiwidCI6Ii4uLiJ9",
+  "expiresAt": "2026-05-04T22:30:00.000Z"
+}
+```
+
+### Response Fields
+
+| Field         | Type   | Description                                           |
+| ------------- | ------ | ----------------------------------------------------- |
+| `runnerId`    | string | Tunnel identifier for subsequent API calls            |
+| `hostnames`   | array  | Public hostnames mapped to local ports                |
+| `tunnelToken` | string | Token to start the cloudflared daemon                 |
+| `expiresAt`   | string | ISO 8601 timestamp when the tunnel expires            |
+
+### Hostname Fields
+
+| Field       | Type    | Description                           |
+| ----------- | ------- | ------------------------------------- |
+| `localPort` | integer | Local port this hostname maps to      |
+| `url`       | string  | Public HTTPS URL for this port        |
+
+### Example: Single Port
+
+```bash
+curl -X POST "https://api.qa.tech/v1/remote-tunnels" \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "ports": [
+      { "localPort": 3000 }
+    ]
+  }'
+```
+
+### Example: Multiple Ports with Subdomains
+
+```bash
+curl -X POST "https://api.qa.tech/v1/remote-tunnels" \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "ports": [
+      { "localPort": 3000, "subdomain": "app" },
+      { "localPort": 8080, "subdomain": "api", "protocol": "http" }
+    ]
+  }'
+```
+
+### Starting the Tunnel
+
+After creating a tunnel, start the cloudflared daemon with the returned token:
+
+```bash
+cloudflared tunnel run --token YOUR_TUNNEL_TOKEN
+```
+
+The tunnel will remain active as long as cloudflared is running.
+
+## List Remote Tunnels
+
+List all active tunnels for your project.
+
+**Endpoint**: `GET /remote-tunnels`
+
+### Response (200)
+
+```json
+{
+  "tunnels": [
+    {
+      "runnerId": "tunnel_abc123",
+      "hostnames": [
+        { "localPort": 3000, "url": "https://r-tunnel_abc123.quack.run" }
+      ],
+      "createdAt": "2026-05-04T10:30:00.000Z",
+      "expiresAt": "2026-05-04T22:30:00.000Z",
+      "isExpired": false
+    },
+    {
+      "runnerId": "tunnel_def456",
+      "hostnames": [
+        { "localPort": 8080, "url": "https://r-tunnel_def456.quack.run" }
+      ],
+      "createdAt": "2026-05-03T14:00:00.000Z",
+      "expiresAt": "2026-05-04T02:00:00.000Z",
+      "isExpired": true
+    }
+  ]
+}
+```
+
+### Response Fields
+
+| Field     | Type  | Description                    |
+| --------- | ----- | ------------------------------ |
+| `tunnels` | array | Array of tunnel summary objects |
+
+### Tunnel Summary Fields
+
+| Field       | Type    | Description                                    |
+| ----------- | ------- | ---------------------------------------------- |
+| `runnerId`  | string  | Tunnel identifier                              |
+| `hostnames` | array   | Public hostnames for the tunnel                |
+| `createdAt` | string  | ISO 8601 creation timestamp                    |
+| `expiresAt` | string  | ISO 8601 expiration timestamp                  |
+| `isExpired` | boolean | Whether the tunnel has expired                 |
+
+### Example
+
+```bash
+curl "https://api.qa.tech/v1/remote-tunnels" \
+  -H "Authorization: Bearer YOUR_API_TOKEN"
+```
+
+## Get Tunnel Status
+
+Check the live health status of a tunnel via Cloudflare.
+
+**Endpoint**: `GET /remote-tunnels/{runnerId}/status`
+
+### Path Parameters
+
+| Parameter  | Type   | Required | Description        |
+| ---------- | ------ | -------- | ------------------ |
+| `runnerId` | string | Yes      | Tunnel identifier  |
+
+### Response (200)
+
+```json
+{
+  "status": "healthy",
+  "connections": 4,
+  "hostnames": [
+    { "localPort": 3000, "url": "https://r-tunnel_abc123.quack.run" }
+  ]
+}
+```
+
+### Response Fields
+
+| Field         | Type    | Description                                           |
+| ------------- | ------- | ----------------------------------------------------- |
+| `status`      | string  | `"inactive"`, `"degraded"`, or `"healthy"`            |
+| `connections` | integer | Number of active Cloudflare edge connections          |
+| `hostnames`   | array   | Public hostnames for the tunnel                       |
+
+### Status Values
+
+| Status     | Connections | Description                          |
+| ---------- | ----------- | ------------------------------------ |
+| `inactive` | 0           | No active connections                |
+| `degraded` | 1-3         | Tunnel is running but not optimal    |
+| `healthy`  | 4+          | Tunnel is fully operational          |
+
+### Example
+
+```bash
+curl "https://api.qa.tech/v1/remote-tunnels/tunnel_abc123/status" \
+  -H "Authorization: Bearer YOUR_API_TOKEN"
+```
+
+## Delete Remote Tunnel
+
+Tear down a tunnel and remove its DNS records.
+
+**Endpoint**: `DELETE /remote-tunnels/{runnerId}`
+
+### Path Parameters
+
+| Parameter  | Type   | Required | Description        |
+| ---------- | ------ | -------- | ------------------ |
+| `runnerId` | string | Yes      | Tunnel identifier  |
+
+### Response (200)
+
+```json
+{
+  "deleted": true
+}
+```
+
+### Example
+
+```bash
+curl -X DELETE "https://api.qa.tech/v1/remote-tunnels/tunnel_abc123" \
+  -H "Authorization: Bearer YOUR_API_TOKEN"
+```
+
+## Complete Workflow Example
+
+Here's a complete example of creating a tunnel, using it for testing, and cleaning up:
+
+```bash
+# 1. Create the tunnel
+TUNNEL_RESPONSE=$(curl -s -X POST "https://api.qa.tech/v1/remote-tunnels" \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"ports": [{"localPort": 3000}]}')
+
+RUNNER_ID=$(echo "$TUNNEL_RESPONSE" | jq -r '.runnerId')
+TUNNEL_TOKEN=$(echo "$TUNNEL_RESPONSE" | jq -r '.tunnelToken')
+PUBLIC_URL=$(echo "$TUNNEL_RESPONSE" | jq -r '.hostnames[0].url')
+
+echo "Tunnel created: $PUBLIC_URL"
+
+# 2. Start cloudflared in the background
+cloudflared tunnel run --token "$TUNNEL_TOKEN" &
+CLOUDFLARED_PID=$!
+
+# 3. Wait for tunnel to become healthy
+sleep 5
+STATUS=$(curl -s "https://api.qa.tech/v1/remote-tunnels/$RUNNER_ID/status" \
+  -H "Authorization: Bearer YOUR_API_TOKEN" | jq -r '.status')
+echo "Tunnel status: $STATUS"
+
+# 4. Run tests against the tunnel URL
+curl -X POST "https://api.qa.tech/v1/run" \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"testPlanShortId\": \"pln_abc123\",
+    \"applications\": [{
+      \"applicationShortId\": \"app_gXeBl2\",
+      \"environment\": {
+        \"url\": \"$PUBLIC_URL\",
+        \"name\": \"Local Tunnel\"
+      }
+    }]
+  }"
+
+# 5. Clean up
+kill $CLOUDFLARED_PID
+curl -X DELETE "https://api.qa.tech/v1/remote-tunnels/$RUNNER_ID" \
+  -H "Authorization: Bearer YOUR_API_TOKEN"
+```
+
+## Error Responses
+
+| Status  | Description                                |
+| ------- | ------------------------------------------ |
+| **400** | Validation error or malformed request      |
+| **401** | Missing or invalid API key                 |
+| **403** | Invalid token or organization suspended    |
+| **404** | Tunnel or project not found                |
+| **500** | Server error                               |
+
+Error responses include a body: `{ "message": "Error description" }`.
+
+## Related
+
+- [Tunnel CLI Command](/cli/commands/tunnel) – CLI interface for tunnel management
+- [SSH Tunnel](/configuration/ssh-tunnel) – Alternative tunneling via SSH
+- [Start Run API](/api-reference/start-run) – Use tunnel URLs as environment overrides
+- [API Introduction](/api-reference/introduction) – Authentication and ID reference

--- a/mint.json
+++ b/mint.json
@@ -162,6 +162,11 @@
         "api-reference/run-status",
         "api-reference/rerun",
         "api-reference/test-cases",
+        "api-reference/list-test-cases",
+        "api-reference/chat",
+        "api-reference/applications",
+        "api-reference/remote-tunnels",
+        "api-reference/application-builds",
         "api-reference/outbound-ips"
       ]
     }

--- a/mint.json
+++ b/mint.json
@@ -157,11 +157,64 @@
       "group": "API Reference",
       "pages": [
         "api-reference/introduction",
-        "api-reference/start-run",
-        "api-reference/run-status",
-        "api-reference/rerun",
-        "api-reference/test-cases",
-        "api-reference/outbound-ips"
+        {
+          "group": "Runs",
+          "pages": [
+            "api-reference/start-run",
+            "api-reference/run-status",
+            "api-reference/rerun"
+          ]
+        },
+        {
+          "group": "Test Cases",
+          "pages": [
+            "api-reference/test-cases",
+            "api-reference/test-cases/list-test-cases"
+          ]
+        },
+        {
+          "group": "Applications",
+          "pages": [
+            "api-reference/applications/list-applications",
+            "api-reference/applications/list-application-environments"
+          ]
+        },
+        {
+          "group": "Application Builds",
+          "pages": [
+            "api-reference/application-builds/get-build-upload-url",
+            "api-reference/application-builds/create-application-build"
+          ]
+        },
+        {
+          "group": "Status Badge",
+          "pages": [
+            "api-reference/status-badge/get-status-badge",
+            "api-reference/status-badge/get-example-status-badge"
+          ]
+        },
+        {
+          "group": "Remote Tunnels",
+          "pages": [
+            "api-reference/remote-tunnels/create-remote-tunnel",
+            "api-reference/remote-tunnels/list-remote-tunnels",
+            "api-reference/remote-tunnels/get-remote-tunnel-status",
+            "api-reference/remote-tunnels/delete-remote-tunnel"
+          ]
+        },
+        {
+          "group": "Chat",
+          "pages": [
+            "api-reference/chat/start-chat-conversation",
+            "api-reference/chat/start-change-review-chat",
+            "api-reference/chat/send-chat-message",
+            "api-reference/chat/get-chat-conversation"
+          ]
+        },
+        {
+          "group": "Infrastructure",
+          "pages": ["api-reference/outbound-ips"]
+        }
       ]
     }
   ],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR adds comprehensive documentation for all previously undocumented API routes and merges in the updated OpenAPI spec from PR #35.

## Changes

### Merged from PR #35: Updated OpenAPI Spec
- **`api-reference/api.json`** — Regenerated from TypeSpec build, now contains all 17 public operations across 8 tags
- OpenAPI auto-generated pages are now available for all endpoints

### New Hand-Written Documentation Pages

These comprehensive guides provide detailed examples, workflow guidance, and practical tips beyond what the OpenAPI spec offers:

#### Chat API (`api-reference/chat.mdx`)
- Complete guide to the 4 Chat API endpoints
- Polling recommendations (2-5 seconds)
- Response time expectations
- Environment override examples
- CLI alternative tips

#### List Test Cases (`api-reference/list-test-cases.mdx`)
- `GET /v1/test-cases` documentation with filtering and pagination
- Notes on when to use test case UUIDs vs test plan IDs

#### Applications API (`api-reference/applications.mdx`)
- Guide to discovering application and environment IDs
- Tips for finding IDs in the dashboard UI

#### Remote Tunnels API (`api-reference/remote-tunnels.mdx`)
- Complete tunnel lifecycle documentation
- **12-hour tunnel expiration warning**
- cloudflared installation prerequisites
- CLI alternative (`qatech tunnel start`)

#### Application Builds API (`api-reference/application-builds.mdx`)
- Two-step upload workflow explanation
- Supported file types (APK, AAB, IPA)
- CI/CD integration examples (GitHub Actions)

### Updated Navigation (`mint.json`)

The API Reference is now organized into subgroups, each containing:
- Hand-written comprehensive guides (where applicable)
- Auto-generated OpenAPI reference pages

| Group | Pages |
|-------|-------|
| Runs | start-run, run-status, rerun |
| Test Cases | test-cases (create), list-test-cases (guide + openapi) |
| Applications | applications (guide), list-applications, list-environments |
| Application Builds | application-builds (guide), get-upload-url, create-build |
| Status Badge | get-status-badge, get-example-badge |
| Remote Tunnels | remote-tunnels (guide), create, list, status, delete |
| Chat | chat (guide), start-conversation, change-review, send-message, get-conversation |
| Infrastructure | outbound-ips |

### Updated `api-reference/introduction.mdx`
- Added new capabilities to "What Can You Do?" section
- Added all new endpoints to "Next Steps"
- Added Chat Conversation ID and Application Build ID to ID reference table

## Note on Status Badge Endpoints

The badge.svg endpoints are public (no auth) and documented in the OpenAPI spec. The existing `integrations/status-badges.mdx` covers the user-facing configuration.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://qadottech.slack.com/archives/C09H6LM2XGB/p1777020193406489?thread_ts=1777020193.406489&cid=C09H6LM2XGB)

<div><a href="https://cursor.com/agents/bc-85a7a0dd-31eb-5968-845e-58edaf2cb63e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85a7a0dd-31eb-5968-845e-58edaf2cb63e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

