### PR TITLE
docs: add Change Review GitHub Action (QAT-6233)

### DIFF
--- a/configuration/ci-cd-integration.mdx
+++ b/configuration/ci-cd-integration.mdx
@@ -71,19 +71,28 @@ QA.tech exploratory review integrations automatically analyze pull/merge request
 4. **Runs tests** - Executes against PR preview deployment
 5. **Posts review** - Comments on the request with test results and approval/rejection
 
+### Ways to trigger a change review
+
+| Trigger                                                                             | Best for                                                                                                       | Posts review to PR/MR?                                                |
+| :---------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------- |
+| **[GitHub App](/configuration/github-app)** (automatic)                             | Default for GitHub: every PR open/sync triggers a review, with environments resolved from the App's mapping    | Yes (native PR review)                                                |
+| **[GitLab MR integration](/configuration/gitlab)** (automatic)                      | GitLab teams with native deployment signals or `@qa.tech` comments                                             | Yes (MR review note)                                                  |
+| **[Change Review Action](/configuration/github-actions#change-review-action)** (CI) | Custom flows on top of the GitHub App: multiple applications per PR, label-gated triggers, deploy-job ordering | Yes (same native PR review the App posts)                             |
+| **[Start change review chat API](/api-reference/chat/start-change-review-chat)**    | GitLab CI or any pipeline that can make HTTP requests                                                          | Yes when invoked with `mode: "pr"` and a connected GitHub/GitLab repo |
+
 ### Requirements
 
-- GitHub App or GitLab integration connected to your repository
-- Preview deployment context available (native deployment signals or manual `@qa.tech` comment with preview URL)
-- Repository selected in QA.tech integration settings
+- Connected VCS integration: the [GitHub App](/configuration/github-app) (for GitHub triggers, including the Change Review Action) or the [GitLab integration](/configuration/gitlab) (for GitLab triggers)
+- Repository selected in **Settings → Integrations** so the review agent has permission to read the PR/MR
+- Preview deployment context available: native deployment signals, a manual `@qa.tech` comment with the preview URL, or `applications_config` supplied to the action/API
 
 <Note>
-AI exploratory testing is available through:
-- **[GitHub App for PR Reviews](/configuration/github-app)** for GitHub pull requests
-- **[GitLab Merge Request Reviews](/configuration/gitlab)** for GitLab merge requests
-
-For other platforms, use API-driven testing.
-
+  All four triggers run the same review agent and post the same native PR/MR
+  review. The difference is who detects the PR and what you can customize around
+  it. Use the automatic GitHub App or GitLab integration for zero-config reviews
+  on every PR/MR; reach for the Change Review Action or API when you need custom
+  orchestration on top of that integration (e.g. routing application short IDs
+  to specific URLs per PR, or gating reviews behind a deploy job).
 </Note>
 
 ## Related Documentation

--- a/configuration/github-actions.mdx
+++ b/configuration/github-actions.mdx
@@ -30,12 +30,11 @@ Trigger a test plan from a workflow. Use this when you want full control over wh
 
 <Steps>
   <Step title="Configure Secrets">
-    Add secrets to your GitHub repository (**Settings → Secrets and variables → Actions**):
+    Add a secret to your GitHub repository (**Settings → Secrets and variables → Actions**):
 
     - `QATECH_API_TOKEN` - Your QA.tech API token
-    - `QATECH_PROJECT_ID` - Your QA.tech project ID
 
-    Find these in your [project settings](https://app.qa.tech/current-project/settings/integrations).
+    Find it in your [project settings](https://app.qa.tech/current-project/settings/integrations).
 
   </Step>
 
@@ -54,7 +53,6 @@ jobs:
     steps:
       - uses: QAdottech/run-action@v3
         with:
-          project_id: ${{ secrets.QATECH_PROJECT_ID }}
           api_token: ${{ secrets.QATECH_API_TOKEN }}
           blocking: true
 ```
@@ -78,7 +76,6 @@ jobs:
     steps:
       - uses: QAdottech/run-action@v3
         with:
-          project_id: ${{ secrets.QATECH_PROJECT_ID }}
           api_token: ${{ secrets.QATECH_API_TOKEN }}
           test_plan_short_id: "smoke-tests"
           blocking: true
@@ -110,7 +107,6 @@ jobs:
     steps:
       - uses: QAdottech/run-action@v3
         with:
-          project_id: ${{ secrets.QATECH_PROJECT_ID }}
           api_token: ${{ secrets.QATECH_API_TOKEN }}
           test_plan_short_id: "regression-suite"
           blocking: true
@@ -141,7 +137,6 @@ jobs:
     steps:
       - uses: QAdottech/run-action@v3
         with:
-          project_id: ${{ secrets.QATECH_PROJECT_ID }}
           api_token: ${{ secrets.QATECH_API_TOKEN }}
           test_plan_short_id: "full-regression"
           blocking: false
@@ -153,7 +148,6 @@ jobs:
 - uses: QAdottech/run-action@v3
   id: qatech
   with:
-    project_id: ${{ secrets.QATECH_PROJECT_ID }}
     api_token: ${{ secrets.QATECH_API_TOKEN }}
     blocking: true
 
@@ -168,12 +162,11 @@ jobs:
 
 | Input                 | Description                                                   | Required | Default               |
 | :-------------------- | :------------------------------------------------------------ | :------- | :-------------------- |
-| `project_id`          | Your QA.tech project ID                                       | Yes      | -                     |
 | `api_token`           | QA.tech API token                                             | Yes      | -                     |
 | `test_plan_short_id`  | Test plan short ID to run                                     | No       | All tests             |
 | `blocking`            | Wait for test results before completing                       | No       | `false`               |
 | `applications_config` | JSON with application environment and device preset overrides | No       | -                     |
-| `api_url`             | Custom API URL                                                | No       | `https://app.qa.tech` |
+| `api_url`             | Custom API URL                                                | No       | `https://api.qa.tech` |
 
 #### Outputs
 
@@ -188,21 +181,6 @@ jobs:
 ## Change Review Action
 
 Trigger a QA.tech autonomous change review on a pull request directly from your workflow. The action calls [`POST /v1/chat/change-review`](/api-reference/chat/start-change-review-chat) with the PR URL and your per-PR environment overrides. QA.tech then runs the same review agent the [GitHub App](/configuration/github-app) uses: it selects relevant tests, fills coverage gaps, runs everything against your preview, and posts a native PR review on GitHub when it's done. The action exposes the chat conversation URL as a workflow output, and (in blocking mode) the agent's final assistant message and status.
-
-### Action vs the GitHub App automatic trigger
-
-Both run the same review agent and both post the same native PR review to GitHub. The action is for cases where the App's automatic trigger is too rigid about _when_ it fires and _which_ application URLs it tests against.
-
-| Capability                                                  | Change Review Action                                                 | GitHub App auto-trigger                                 |
-| :---------------------------------------------------------- | :------------------------------------------------------------------- | :------------------------------------------------------ |
-| Runs the same change review agent                           | Yes                                                                  | Yes                                                     |
-| Posts a native PR review on GitHub                          | Yes                                                                  | Yes                                                     |
-| Picks app URLs per PR (e.g. multiple apps, branch-specific) | Yes (you supply `applications_config`)                               | Limited (static environment mapping)                    |
-| Trigger logic (labels, paths, gated on a deploy job)        | You define it in the workflow                                        | Fires on every PR open/sync                             |
-| Exposes chat URL and agent status as workflow outputs       | Yes (`chat_url` always; `chat_status`/`chat_response` when blocking) | No (chat URL is linked from the review comment instead) |
-| Requires the [GitHub App](/configuration/github-app)        | Yes (installed + repo mapped)                                        | Yes                                                     |
-
-If the App's automatic trigger works for you, prefer it: zero workflow code. Reach for the action when you need custom orchestration on top.
 
 ### Setup
 

--- a/configuration/github-actions.mdx
+++ b/configuration/github-actions.mdx
@@ -8,12 +8,12 @@ The [`QAdottech/run-action`](https://github.com/QAdottech/run-action) repository
 
 | Action                                        | Path                                    | What it does                                                                                        |
 | :-------------------------------------------- | :-------------------------------------- | :-------------------------------------------------------------------------------------------------- |
-| [Test Plan Action](#test-plan-action)         | `QAdottech/run-action@v3`               | Trigger a specific test plan on demand. Full control over which tests run and against which URL.    |
+| [Test Run Action](#test-run-action)           | `QAdottech/run-action@v3`               | Trigger a specific test plan on demand. Full control over which tests run and against which URL.    |
 | [Change Review Action](#change-review-action) | `QAdottech/run-action/change-review@v3` | Trigger a QA.tech autonomous change review on a pull request and (optionally) wait for the verdict. |
 
 <Note>
 **Picking an integration mode:**
-- Use the **Test Plan Action** for regression suites, scheduled runs, and deployment gates where you decide which tests run.
+- Use the **Test Run Action** for regression suites, scheduled runs, and deployment gates where you decide which tests run.
 - Use the **Change Review Action** when the [GitHub App's](/configuration/github-app) automatic PR review is not flexible enough. Common cases: projects with more than one application per PR (where the App's environment mapping is fiddly), workflows that need to trigger reviews on labels or after a specific deploy job, or pipelines that need to route specific application short IDs to specific preview URLs per PR.
 
 Both actions live in the same [`QAdottech/run-action`](https://github.com/QAdottech/run-action) repo. The Change Review Action calls the same review agent the GitHub App runs and **requires the GitHub App to be installed and the repository mapped to the project**; it just lets you drive the review from CI instead of (or alongside) the App's automatic trigger.
@@ -22,7 +22,7 @@ See [CI/CD Integration](/configuration/ci-cd-integration) for the broader pictur
 
 </Note>
 
-## Test Plan Action
+## Test Run Action
 
 Trigger a test plan from a workflow. Use this when you want full control over which tests run, when, and where.
 
@@ -156,7 +156,7 @@ jobs:
   run: echo "Tests failed! See ${{ steps.qatech.outputs.run_url }}"
 ```
 
-### Test Plan Action reference
+### Test Run Action reference
 
 #### Inputs
 
@@ -199,9 +199,9 @@ The Change Review Action runs the same agent as the GitHub App, so the App still
 </Step>
 
 <Step title="Configure Secrets">
-  Reuse the `QATECH_API_TOKEN` secret from the Test Plan Action setup. The
-  Change Review Action does not need `project_id`; your API token already scopes
-  the request to a project.
+  Reuse the `QATECH_API_TOKEN` secret from the Test Run Action setup. The Change
+  Review Action does not need `project_id`; your API token already scopes the
+  request to a project.
 </Step>
 
 <Step title="Find your application short IDs">

--- a/configuration/github-actions.mdx
+++ b/configuration/github-actions.mdx
@@ -1,27 +1,44 @@
 ---
 title: GitHub Actions
-description: 'Integrate QA.tech testing into GitHub Actions workflows'
-icon: 'github'
+description: "Integrate QA.tech testing and PR reviews into GitHub Actions workflows"
+icon: "github"
 ---
 
-Use the official QA.tech GitHub Action to trigger test runs from your workflows. This gives you full control over which test plans run, when they run, and which environments to test.
+The [`QAdottech/run-action`](https://github.com/QAdottech/run-action) repository ships two GitHub Actions you can use from any workflow:
+
+| Action                                        | Path                                    | What it does                                                                                        |
+| :-------------------------------------------- | :-------------------------------------- | :-------------------------------------------------------------------------------------------------- |
+| [Test Plan Action](#test-plan-action)         | `QAdottech/run-action@v3`               | Trigger a specific test plan on demand. Full control over which tests run and against which URL.    |
+| [Change Review Action](#change-review-action) | `QAdottech/run-action/change-review@v3` | Trigger a QA.tech autonomous change review on a pull request and (optionally) wait for the verdict. |
 
 <Note>
-**Looking for AI-powered testing?** The [GitHub App](/configuration/github-app) provides automatic test creation and PR reviews. This page covers the GitHub Action for API-driven testing.
+**Picking an integration mode:**
+- Use the **Test Plan Action** for regression suites, scheduled runs, and deployment gates where you decide which tests run.
+- Use the **Change Review Action** when the [GitHub App's](/configuration/github-app) automatic PR review is not flexible enough. Common cases: projects with more than one application per PR (where the App's environment mapping is fiddly), workflows that need to trigger reviews on labels or after a specific deploy job, or pipelines that need to route specific application short IDs to specific preview URLs per PR.
+
+Both actions live in the same [`QAdottech/run-action`](https://github.com/QAdottech/run-action) repo. The Change Review Action calls the same review agent the GitHub App runs and **requires the GitHub App to be installed and the repository mapped to the project**; it just lets you drive the review from CI instead of (or alongside) the App's automatic trigger.
+
+See [CI/CD Integration](/configuration/ci-cd-integration) for the broader picture.
+
 </Note>
 
-## Setup
+## Test Plan Action
+
+Trigger a test plan from a workflow. Use this when you want full control over which tests run, when, and where.
+
+### Setup
 
 <Steps>
   <Step title="Configure Secrets">
     Add secrets to your GitHub repository (**Settings → Secrets and variables → Actions**):
-    
+
     - `QATECH_API_TOKEN` - Your QA.tech API token
     - `QATECH_PROJECT_ID` - Your QA.tech project ID
-    
+
     Find these in your [project settings](https://app.qa.tech/current-project/settings/integrations).
+
   </Step>
-  
+
   <Step title="Create Workflow">
     Create `.github/workflows/qatech.yml`:
 
@@ -35,18 +52,19 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: QAdottech/run-action@v2
+      - uses: QAdottech/run-action@v3
         with:
           project_id: ${{ secrets.QATECH_PROJECT_ID }}
           api_token: ${{ secrets.QATECH_API_TOKEN }}
           blocking: true
 ```
+
   </Step>
 </Steps>
 
-## Implementation Patterns
+### Implementation patterns
 
-### Run on Pull Requests
+#### Run on pull requests
 
 ```yaml
 name: PR Tests
@@ -58,15 +76,15 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: QAdottech/run-action@v2
+      - uses: QAdottech/run-action@v3
         with:
           project_id: ${{ secrets.QATECH_PROJECT_ID }}
           api_token: ${{ secrets.QATECH_API_TOKEN }}
-          test_plan_short_id: 'smoke-tests'
+          test_plan_short_id: "smoke-tests"
           blocking: true
 ```
 
-### Test Preview Deployments
+#### Test preview deployments
 
 ```yaml
 name: Test Preview
@@ -90,11 +108,11 @@ jobs:
     needs: deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: QAdottech/run-action@v2
+      - uses: QAdottech/run-action@v3
         with:
           project_id: ${{ secrets.QATECH_PROJECT_ID }}
           api_token: ${{ secrets.QATECH_API_TOKEN }}
-          test_plan_short_id: 'regression-suite'
+          test_plan_short_id: "regression-suite"
           blocking: true
           applications_config: |
             {
@@ -109,30 +127,30 @@ jobs:
             }
 ```
 
-### Scheduled Testing
+#### Scheduled testing
 
 ```yaml
 name: Nightly Tests
 on:
   schedule:
-    - cron: '0 2 * * *'  # Daily at 2 AM UTC
+    - cron: "0 2 * * *" # Daily at 2 AM UTC
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: QAdottech/run-action@v2
+      - uses: QAdottech/run-action@v3
         with:
           project_id: ${{ secrets.QATECH_PROJECT_ID }}
           api_token: ${{ secrets.QATECH_API_TOKEN }}
-          test_plan_short_id: 'full-regression'
+          test_plan_short_id: "full-regression"
           blocking: false
 ```
 
-### Use Action Outputs
+#### Use action outputs
 
 ```yaml
-- uses: QAdottech/run-action@v2
+- uses: QAdottech/run-action@v3
   id: qatech
   with:
     project_id: ${{ secrets.QATECH_PROJECT_ID }}
@@ -144,36 +162,284 @@ jobs:
   run: echo "Tests failed! See ${{ steps.qatech.outputs.run_url }}"
 ```
 
-## Action Reference
+### Test Plan Action reference
 
-### Inputs
+#### Inputs
 
-| Input | Description | Required | Default |
-|:------|:------------|:---------|:--------|
-| `project_id` | Your QA.tech project ID | Yes | - |
-| `api_token` | QA.tech API token | Yes | - |
-| `test_plan_short_id` | Test plan short ID to run | No | All tests |
-| `blocking` | Wait for test results before completing | No | `false` |
-| `applications_config` | JSON with application environment and device preset overrides | No | - |
-| `api_url` | Custom API URL | No | `https://app.qa.tech` |
+| Input                 | Description                                                   | Required | Default               |
+| :-------------------- | :------------------------------------------------------------ | :------- | :-------------------- |
+| `project_id`          | Your QA.tech project ID                                       | Yes      | -                     |
+| `api_token`           | QA.tech API token                                             | Yes      | -                     |
+| `test_plan_short_id`  | Test plan short ID to run                                     | No       | All tests             |
+| `blocking`            | Wait for test results before completing                       | No       | `false`               |
+| `applications_config` | JSON with application environment and device preset overrides | No       | -                     |
+| `api_url`             | Custom API URL                                                | No       | `https://app.qa.tech` |
 
-### Outputs
+#### Outputs
 
-| Output | Description |
-|:-------|:------------|
-| `run_created` | Whether the test run was created successfully |
-| `run_short_id` | The short ID of the run |
-| `run_url` | The URL of the run |
-| `run_status` | Final status (`COMPLETED`, `ERROR`, `CANCELLED`) - only when `blocking: true` |
-| `run_result` | Test result (`PASSED`, `FAILED`, `SKIPPED`) - only when `blocking: true` |
+| Output         | Description                                                                   |
+| :------------- | :---------------------------------------------------------------------------- |
+| `run_created`  | Whether the test run was created successfully                                 |
+| `run_short_id` | The short ID of the run                                                       |
+| `run_url`      | The URL of the run                                                            |
+| `run_status`   | Final status (`COMPLETED`, `ERROR`, `CANCELLED`) - only when `blocking: true` |
+| `run_result`   | Test result (`PASSED`, `FAILED`, `SKIPPED`) - only when `blocking: true`      |
 
-## Direct API Alternative
+## Change Review Action
 
-If you prefer curl over the Action, use the [Start Run API](/api-reference/start-run) to trigger runs and the [Run Status API](/api-reference/run-status) for polling in non-blocking workflows.
+Trigger a QA.tech autonomous change review on a pull request directly from your workflow. The action calls [`POST /v1/chat/change-review`](/api-reference/chat/start-change-review-chat) with the PR URL and your per-PR environment overrides. QA.tech then runs the same review agent the [GitHub App](/configuration/github-app) uses: it selects relevant tests, fills coverage gaps, runs everything against your preview, and posts a native PR review on GitHub when it's done. The action exposes the chat conversation URL as a workflow output, and (in blocking mode) the agent's final assistant message and status.
 
-## Related Documentation
+### Action vs the GitHub App automatic trigger
+
+Both run the same review agent and both post the same native PR review to GitHub. The action is for cases where the App's automatic trigger is too rigid about _when_ it fires and _which_ application URLs it tests against.
+
+| Capability                                                  | Change Review Action                                                 | GitHub App auto-trigger                                 |
+| :---------------------------------------------------------- | :------------------------------------------------------------------- | :------------------------------------------------------ |
+| Runs the same change review agent                           | Yes                                                                  | Yes                                                     |
+| Posts a native PR review on GitHub                          | Yes                                                                  | Yes                                                     |
+| Picks app URLs per PR (e.g. multiple apps, branch-specific) | Yes (you supply `applications_config`)                               | Limited (static environment mapping)                    |
+| Trigger logic (labels, paths, gated on a deploy job)        | You define it in the workflow                                        | Fires on every PR open/sync                             |
+| Exposes chat URL and agent status as workflow outputs       | Yes (`chat_url` always; `chat_status`/`chat_response` when blocking) | No (chat URL is linked from the review comment instead) |
+| Requires the [GitHub App](/configuration/github-app)        | Yes (installed + repo mapped)                                        | Yes                                                     |
+
+If the App's automatic trigger works for you, prefer it: zero workflow code. Reach for the action when you need custom orchestration on top.
+
+### Setup
+
+The Change Review Action runs the same agent as the GitHub App, so the App still needs to be installed and the repository mapped to your project. The action then drives that agent from CI.
+
+<Steps>
+  <Step title="Install the GitHub App and map your repository">
+    If you haven't already, follow [Install GitHub App](/configuration/github-app#how-to-set-it-up) to connect the App at the organization level and select your repository under **Settings → Integrations → GitHub App**. Without this, the action's chat will start but the agent has no permission to read your PR.
+  </Step>
+
+<Step title="Disable Auto-run on PRs (optional)">
+  If you want the action to be the only thing that triggers reviews on this
+  repo, open **Settings → Integrations → GitHub App** and turn off **Auto-run on
+  PRs**. Leave it on if you want both the automatic trigger and on-demand action
+  runs.
+</Step>
+
+<Step title="Configure Secrets">
+  Reuse the `QATECH_API_TOKEN` secret from the Test Plan Action setup. The
+  Change Review Action does not need `project_id`; your API token already scopes
+  the request to a project.
+</Step>
+
+<Step title="Find your application short IDs">
+  Open **Test Plans → API Integration** in QA.tech to see which applications
+  belong to your project. Each application has a short ID (e.g. `app_ONdgMD`)
+  that you pass in `applications_config`. Projects with more than one
+  application should pass one entry per app so the agent knows which URL to test
+  against.
+</Step>
+
+  <Step title="Create Workflow">
+    Create `.github/workflows/qatech-change-review.yml`:
+
+```yaml
+name: QA.tech Change Review
+on:
+  pull_request:
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: QAdottech/run-action/change-review@v3
+        with:
+          api_token: ${{ secrets.QATECH_API_TOKEN }}
+          applications_config: |
+            {
+              "applications": {
+                "app_ONdgMD": {
+                  "environment": {
+                    "url": "https://preview-${{ github.event.number }}.example.com"
+                  }
+                }
+              }
+            }
+```
+
+    On `pull_request` events the action reads the PR URL from `github.event.pull_request.html_url` automatically, so `pr_url` is optional.
+
+  </Step>
+</Steps>
+
+### Implementation patterns
+
+#### Block the workflow until the review finishes
+
+By default the action returns as soon as the chat conversation is created and the agent starts working. Set `blocking: true` to wait for the agent to finish (and post its native PR review) before the workflow step completes. The step fails when the review ends in `FAILED` or `CANCELLED`, which makes it suitable as a deployment gate.
+
+```yaml
+- uses: QAdottech/run-action/change-review@v3
+  id: review
+  with:
+    api_token: ${{ secrets.QATECH_API_TOKEN }}
+    blocking: true
+    applications_config: |
+      {
+        "applications": {
+          "app_ONdgMD": {
+            "environment": {
+              "url": "https://preview-${{ github.event.number }}.example.com"
+            }
+          }
+        }
+      }
+
+- name: Log conversation
+  if: always()
+  run: |
+    echo "Status: ${{ steps.review.outputs.chat_status }}"
+    echo "Conversation URL: ${{ steps.review.outputs.chat_url }}"
+    echo "Final assistant message: ${{ steps.review.outputs.chat_response }}"
+```
+
+The native review is posted to the PR by the agent itself. `chat_response` is the agent's final assistant text in the chat (which may summarize what it did but is not the GitHub review body); use it for logging or further automation, not as a replacement for the PR review.
+
+#### Route multiple applications to per-PR preview URLs
+
+The most common reason to reach for this action over the GitHub App's automatic trigger: projects with more than one application per PR (for example a frontend, a backend, and an admin dashboard). Pass one entry per application so the agent knows which preview URL to use for each. Each entry must include an `environment` with at least one of `url`, `shortId`, or `applicationBuildShortId`.
+
+```yaml
+- uses: QAdottech/run-action/change-review@v3
+  with:
+    api_token: ${{ secrets.QATECH_API_TOKEN }}
+    applications_config: |
+      {
+        "applications": {
+          "app_frontend": {
+            "environment": {
+              "url": "https://preview-${{ github.event.number }}-web.example.com",
+              "name": "PR-${{ github.event.number }}"
+            }
+          },
+          "app_backend": {
+            "environment": {
+              "url": "https://preview-${{ github.event.number }}-api.example.com",
+              "name": "PR-${{ github.event.number }}"
+            }
+          }
+        }
+      }
+```
+
+#### Override the device preset
+
+Pass `devicePresetShortId` alongside `environment` to run the review against a specific [device preset](/test-features/device-presets):
+
+```yaml
+applications_config: |
+  {
+    "applications": {
+      "app_frontend": {
+        "environment": { "url": "https://preview.example.com" },
+        "devicePresetShortId": "preset_mobile_abc123"
+      }
+    }
+  }
+```
+
+#### Add free-form context
+
+Use the `context` input to guide the review with PR-specific or repo-wide instructions:
+
+```yaml
+- uses: QAdottech/run-action/change-review@v3
+  with:
+    api_token: ${{ secrets.QATECH_API_TOKEN }}
+    context: |
+      Focus on the new Apple Pay flow. Test login is shared with the existing
+      checkout test and uses test-user@example.com.
+    applications_config: |
+      { "applications": { "app_ONdgMD": { "environment": { "url": "https://preview.example.com" } } } }
+```
+
+#### Review a different PR
+
+Set `pr_url` when the workflow runs outside a `pull_request` event (for example on `workflow_dispatch`):
+
+```yaml
+on:
+  workflow_dispatch:
+    inputs:
+      pr_url:
+        description: PR to review
+        required: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: QAdottech/run-action/change-review@v3
+        with:
+          api_token: ${{ secrets.QATECH_API_TOKEN }}
+          pr_url: ${{ inputs.pr_url }}
+          applications_config: |
+            { "applications": { "app_ONdgMD": { "environment": { "url": "https://staging.example.com" } } } }
+```
+
+### Change Review Action reference
+
+#### Inputs
+
+| Input                 | Description                                                                                                                                                         | Required | Default                    |
+| :-------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :------- | :------------------------- |
+| `api_token`           | QA.tech API token                                                                                                                                                   | Yes      | -                          |
+| `applications_config` | JSON of `{ "applications": { "<applicationShortId>": { "environment": { ... }, "devicePresetShortId": "..." } } }`. Each application must include an `environment`. | Yes      | -                          |
+| `blocking`            | Wait for the assistant reply and expose it as an output. Fails the step on `FAILED` or `CANCELLED`.                                                                 | No       | `false`                    |
+| `context`             | Free-form context appended to the review.                                                                                                                           | No       | -                          |
+| `pr_url`              | Pull request URL to review. Defaults to the PR URL of the current `pull_request` event.                                                                             | No       | Auto-detected on PR events |
+| `api_url`             | Custom API URL.                                                                                                                                                     | No       | `https://api.qa.tech`      |
+
+Each environment in `applications_config` must include one of:
+
+- `url` (plus optional `name`) to point the application at a preview URL.
+- `shortId` to reference an existing environment short ID.
+- `applicationBuildShortId` to reference a previously uploaded mobile build.
+
+See [Start change review chat API](/api-reference/chat/start-change-review-chat) for the request schema this maps to.
+
+#### Outputs
+
+The agent posts its review natively on the PR. These outputs let you link to or log the chat conversation from your workflow; they are not the PR review body.
+
+| Output          | Description                                                                                                                                           |
+| :-------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `chat_created`  | `"true"` when the chat conversation was created successfully.                                                                                         |
+| `chat_short_id` | Short ID of the change review chat conversation (e.g. `chat_abc123`).                                                                                 |
+| `chat_url`      | Dashboard URL of the chat. Always set, even when not blocking.                                                                                        |
+| `chat_status`   | Final status of the agent's assistant message: `COMPLETED`, `FAILED`, or `CANCELLED`. Only set when `blocking: true`.                                 |
+| `chat_response` | The agent's final assistant text in the chat (free-form, may summarize what was done). Not the GitHub PR review body. Only set when `blocking: true`. |
+
+### How polling works
+
+When `blocking: true`, the action polls [`GET /v1/chat/{chat_short_id}`](/api-reference/chat/get-chat-conversation) every 20 seconds until the latest assistant message reaches a terminal status:
+
+| Assistant status | Action behavior                                                          |
+| :--------------- | :----------------------------------------------------------------------- |
+| `INITIATED`      | Continues polling.                                                       |
+| `PARTIAL`        | Continues polling.                                                       |
+| `COMPLETED`      | Sets `chat_status` and `chat_response`. Step succeeds.                   |
+| `FAILED`         | Sets `chat_status` and `chat_response`. Step fails via `core.setFailed`. |
+| `CANCELLED`      | Sets `chat_status` and `chat_response`. Step fails via `core.setFailed`. |
+
+There is no built-in timeout. Set a [`timeout-minutes`](https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution#jobsjob_idstepstimeout-minutes) on the step if you need one.
+
+## Direct API alternatives
+
+If you prefer `curl` over the Actions:
+
+- Test runs: use the [Start Run API](/api-reference/start-run) to trigger runs and the [Run Status API](/api-reference/run-status) for polling.
+- Change reviews: use the [Start change review chat API](/api-reference/chat/start-change-review-chat) and poll with [Get chat conversation](/api-reference/chat/get-chat-conversation) until the latest assistant message reaches `COMPLETED`.
+
+## Related documentation
 
 - **[CI/CD Integration](/configuration/ci-cd-integration)** - Overview of integration modes
-- **[GitHub App](/configuration/github-app)** - AI-powered automatic PR reviews
-- **[API Reference](/api-reference/start-run)** - Complete API documentation
+- **[GitHub App](/configuration/github-app)** - AI-powered automatic PR reviews via the GitHub App
+- **[GitLab](/configuration/gitlab)** - Same patterns for GitLab CI and merge request reviews
+- **[Start Run API](/api-reference/start-run)** - Complete test-run API documentation
+- **[Start change review chat API](/api-reference/chat/start-change-review-chat)** - Complete change review API documentation
 - **[Notifications](/core-concepts/notifications)** - Slack notification configuration

--- a/configuration/github-actions.mdx
+++ b/configuration/github-actions.mdx
@@ -170,13 +170,13 @@ jobs:
 
 #### Outputs
 
-| Output         | Description                                                                   |
-| :------------- | :---------------------------------------------------------------------------- |
-| `run_created`  | Whether the test run was created successfully                                 |
-| `run_short_id` | The short ID of the run                                                       |
-| `run_url`      | The URL of the run                                                            |
-| `run_status`   | Final status (`COMPLETED`, `ERROR`, `CANCELLED`) - only when `blocking: true` |
-| `run_result`   | Test result (`PASSED`, `FAILED`, `SKIPPED`) - only when `blocking: true`      |
+| Output         | Description                                                                                   |
+| :------------- | :-------------------------------------------------------------------------------------------- |
+| `run_created`  | Whether the test run was created successfully                                                 |
+| `run_short_id` | The short ID of the run                                                                       |
+| `run_url`      | The URL of the run                                                                            |
+| `run_status`   | Final status (`COMPLETED`, `ERROR`, `CANCELLED`, or `TIMED_OUT`) - only when `blocking: true` |
+| `run_result`   | Test result (`PASSED`, `FAILED`, `SKIPPED`) - only when `blocking: true`                      |
 
 ## Change Review Action
 
@@ -389,22 +389,23 @@ The agent posts its review natively on the PR. These outputs let you link to or 
 | `chat_created`  | `"true"` when the chat conversation was created successfully.                                                                                         |
 | `chat_short_id` | Short ID of the change review chat conversation (e.g. `chat_abc123`).                                                                                 |
 | `chat_url`      | Dashboard URL of the chat. Always set, even when not blocking.                                                                                        |
-| `chat_status`   | Final status of the agent's assistant message: `COMPLETED`, `FAILED`, or `CANCELLED`. Only set when `blocking: true`.                                 |
+| `chat_status`   | Final status of the agent's assistant message: `COMPLETED`, `FAILED`, `CANCELLED`, or `TIMED_OUT`. Only set when `blocking: true`.                    |
 | `chat_response` | The agent's final assistant text in the chat (free-form, may summarize what was done). Not the GitHub PR review body. Only set when `blocking: true`. |
 
 ### How polling works
 
 When `blocking: true`, the action polls [`GET /v1/chat/{chat_short_id}`](/api-reference/chat/get-chat-conversation) every 20 seconds until the latest assistant message reaches a terminal status:
 
-| Assistant status | Action behavior                                                          |
-| :--------------- | :----------------------------------------------------------------------- |
-| `INITIATED`      | Continues polling.                                                       |
-| `PARTIAL`        | Continues polling.                                                       |
-| `COMPLETED`      | Sets `chat_status` and `chat_response`. Step succeeds.                   |
-| `FAILED`         | Sets `chat_status` and `chat_response`. Step fails via `core.setFailed`. |
-| `CANCELLED`      | Sets `chat_status` and `chat_response`. Step fails via `core.setFailed`. |
+| Assistant status       | Action behavior                                                          |
+| :--------------------- | :----------------------------------------------------------------------- |
+| `INITIATED`            | Continues polling.                                                       |
+| `PARTIAL`              | Continues polling.                                                       |
+| `COMPLETED`            | Sets `chat_status` and `chat_response`. Step succeeds.                   |
+| `FAILED`               | Sets `chat_status` and `chat_response`. Step fails via `core.setFailed`. |
+| `CANCELLED`            | Sets `chat_status` and `chat_response`. Step fails via `core.setFailed`. |
+| _(60 minutes elapsed)_ | Sets `chat_status` to `TIMED_OUT`. Step fails via `core.setFailed`.      |
 
-There is no built-in timeout. Set a [`timeout-minutes`](https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution#jobsjob_idstepstimeout-minutes) on the step if you need one.
+Polling stops after an internal 60-minute timeout. Set a shorter [`timeout-minutes`](https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution#jobsjob_idstepstimeout-minutes) on the step if you need a tighter cap.
 
 ## Direct API alternatives
 

--- a/configuration/github-app.mdx
+++ b/configuration/github-app.mdx
@@ -115,7 +115,11 @@ Selected: 12 tests covering payment & checkout flows
 Tests are created only when coverage gaps exist, such as when you're developing a new feature not yet covered by your testing suite.
 
 <Tip>
-  **Writing acceptance criteria?** Include test requirements in your Linear/Jira ticket or PR description. The agent reads this context and uses it to create more accurate tests for your new feature. See [Recommended Workflow for New Features](/best-practices/creating-tests#recommended-workflow-for-new-features) for details.
+  **Writing acceptance criteria?** Include test requirements in your Linear/Jira
+  ticket or PR description. The agent reads this context and uses it to create
+  more accurate tests for your new feature. See [Recommended Workflow for New
+  Features](/best-practices/creating-tests#recommended-workflow-for-new-features)
+  for details.
 </Tip>
 
 | PR Type          | Existing Tests Selected | New Tests Created       | Total |
@@ -250,6 +254,14 @@ No. The agent only creates tests for coverage gaps - most PRs (bug fixes, refact
 **Can I control which tests run?**
 
 The GitHub App is fully autonomous. For manual test selection, use [GitHub Actions](/configuration/github-actions) instead. You can use both: automatic PR reviews + manual deep testing on-demand.
+
+**My project has multiple applications per PR and the App's environment mapping isn't a good fit. What can I do?**
+
+Install the GitHub App as usual, then turn off **Auto-run on PRs** in **Settings → Integrations → GitHub App** and drive reviews from CI with the [Change Review Action](/configuration/github-actions#change-review-action). The action runs the same review agent (and posts the same native PR review) but lets you pass an `applications_config` per PR, so you can route each application short ID to its own preview URL without relying on the App's static environment mapping.
+
+**Can I gate reviews on labels, paths, or a specific deploy job?**
+
+Yes. Use the [Change Review Action](/configuration/github-actions#change-review-action) instead of the automatic trigger and put the gating logic in your workflow (`if:` conditions on labels or paths, `needs:` on a deploy job, etc.). Disable **Auto-run on PRs** if you want only the action to fire; the action posts the native PR review the same way the App does.
 
 **PR reviews aren't posting - what should I check?**
 


### PR DESCRIPTION
## Summary

Documents the new `QAdottech/run-action/change-review` GitHub Action ([run-action#12](https://github.com/QAdottech/run-action/pull/12)) as a CI-driven way to invoke the same review agent the [GitHub App](https://docs.qa.tech/configuration/github-app) runs.

### Why
Projects with multiple applications per PR (or workflows that need label/path/deploy-job gating) currently can't get a clean change review experience from the GitHub App alone — its environment mapping is static and the trigger fires on every PR open/sync. The new action lets teams keep the App installed (still required for the agent to read PR data) but disable Auto-run on PRs and drive reviews from CI with per-PR `applications_config`.

### What changed

- **`configuration/github-actions.mdx`** — restructured into two clearly delineated sections:
  - **Test Plan Action** (existing content, version refs bumped to `@v3`)
  - **Change Review Action** (new) — setup steps (App install + repo mapping + optional Auto-run disable), six implementation patterns (auto PR URL on `pull_request`, blocking mode, multi-app routing, device preset override, free-form context, `workflow_dispatch` flow), inputs/outputs reference, polling semantics table
- **`configuration/ci-cd-integration.mdx`** — added a "Ways to trigger a change review" comparison covering the four trigger paths (GitHub App, GitLab integration, Change Review Action, raw API)
- **`configuration/github-app.mdx`** — added two Q&A entries pointing GitHub App users to the action when they need per-PR app URL routing or trigger gating

### Verified against source

- `~/dev/run-action` PR branch (`change-review/action.yml`, `src/change-review.ts`, `src/api-client.ts`, `src/util.ts`, `src/__tests__/change-review.test.ts`)
- `apps/api/src/v1/routes/chat/changeReview.ts` (endpoint behavior, source: `api`)
- `packages/chat-helpers/src/tools/vcs-provider-utils.ts` (GitHub App connection + repo mapping requirement)
- `packages/chat-helpers/src/tools/add-vcs-pull-request-review.ts` (agent posts native PR review)
- `api-reference/api.json` (schemas: `StartChangeReviewFromPrRequest`, `ChatConversationResponse`, `ApplicationOverrideWithRequiredEnvironment`)

## Test plan

- [ ] Confirm Mintlify renders the comparison tables outside `<Note>` (Mintlify hides table headers inside callouts)
- [ ] Confirm all internal links resolve (`/api-reference/chat/start-change-review-chat`, `/api-reference/chat/get-chat-conversation`, `/configuration/github-app`, `/configuration/gitlab`, `/test-features/device-presets`)
- [ ] Once the action is released, confirm the `@v3` version reference in examples matches the tagged release


Made with [Cursor](https://cursor.com)