### PR TITLE
docs: document post-merge and API-triggered change reviews for teams without preview environments

### DIFF
--- a/configuration/github-actions.mdx
+++ b/configuration/github-actions.mdx
@@ -277,6 +277,62 @@ By default the action returns as soon as the chat conversation is created and th
 
 The native review is posted to the PR by the agent itself. `chat_response` is the agent's final assistant text in the chat (which may summarize what it did but is not the GitHub review body); use it for logging or further automation, not as a replacement for the PR review.
 
+#### Post-merge change review (no preview environments)
+
+If you do not have per-PR preview environments, run the change review **after** merging to your main branch. The workflow deploys to staging/production, extracts the PR number from the merge commit, and reviews the merged PR's changes against the deployed environment. Results are posted back on the merged PR as a comment.
+
+```yaml
+name: Deploy and Review
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      # Your existing deploy steps here
+      - run: echo "Deploy to staging..."
+
+  change-review:
+    needs: deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract PR number from merge commit
+        id: pr
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          PR_NUMBER=$(echo "$COMMIT_MSG" | grep -oE '\(#[0-9]+\)' | tail -1 | grep -oE '[0-9]+')
+          if [ -n "$PR_NUMBER" ]; then
+            echo "url=https://github.com/${{ github.repository }}/pull/$PR_NUMBER" >> "$GITHUB_OUTPUT"
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Start QA.tech change review
+        if: steps.pr.outputs.found == 'true'
+        uses: QAdottech/run-action/change-review@v3
+        with:
+          api_token: ${{ secrets.QATECH_API_TOKEN }}
+          pr_url: ${{ steps.pr.outputs.url }}
+          context: "This PR has already been merged and deployed. Test the changes and report any issues found as a comment."
+          applications_config: |
+            {
+              "applications": {
+                "app_ONdgMD": {
+                  "environment": {
+                    "url": "https://staging.example.com"
+                  }
+                }
+              }
+            }
+```
+
+Notes:
+
+- The PR number is extracted from GitHub's default merge/squash commit message format (`(#123)`).
+- Direct pushes to `main` without a PR are skipped automatically (the review step is gated on `steps.pr.outputs.found`).
+- Results are posted back on the merged PR as a comment, since the PR is already closed.
+
 #### Route multiple applications to per-PR preview URLs
 
 The most common reason to reach for this action over the GitHub App's automatic trigger: projects with more than one application per PR (for example a frontend, a backend, and an admin dashboard). Pass one entry per application so the agent knows which preview URL to use for each. Each entry must include an `environment` with at least one of `url`, `shortId`, or `applicationBuildShortId`.

--- a/configuration/gitlab.mdx
+++ b/configuration/gitlab.mdx
@@ -278,6 +278,80 @@ See [Test Plans](/core-concepts/test-plans#scheduled-execution) for QA.tech sche
 
 </Accordion>
 
+## Post-merge change reviews (no preview environments)
+
+If you do not have preview environments for merge requests, you can run QA.tech change reviews **after** merging to your main branch. This tests the changes from each MR against your staging or production environment once they're deployed.
+
+**How it works**
+
+1. An MR is merged to `main`/`dev`/`staging`.
+2. Your deploy job deploys to staging/production.
+3. CI extracts the MR number from the merge commit message.
+4. The agent fetches the MR details (diff, changed files, description).
+5. Tests run against your deployed environment.
+6. Results are posted back on the merged MR as a note.
+
+```yaml
+stages:
+  - deploy
+  - review
+
+deploy:
+  stage: deploy
+  only:
+    - main
+  script:
+    - echo "Your deploy steps..."
+
+change-review:
+  stage: review
+  needs: [deploy]
+  only:
+    - main
+  script: |
+    MR_IID=$(echo "$CI_COMMIT_MESSAGE" | grep -oE '![0-9]+' | tail -1 | tr -d '!')
+    if [ -z "$MR_IID" ]; then
+      echo "No MR number found in commit message, skipping"
+      exit 0
+    fi
+    MR_URL="${CI_PROJECT_URL}/-/merge_requests/${MR_IID}"
+    curl -sSf -X POST "https://api.qa.tech/v1/chat/change-review" \
+      -H "Authorization: Bearer ${QA_TECH_API_TOKEN}" \
+      -H "Content-Type: application/json" \
+      -d "{
+        \"mode\": \"pr\",
+        \"prUrl\": \"${MR_URL}\",
+        \"vcsProviderId\": \"gitlab\",
+        \"applicationOverrides\": [{
+          \"applicationShortId\": \"${QATECH_APP_SHORT_ID}\",
+          \"environment\": { \"url\": \"${STAGING_URL}\" }
+        }],
+        \"context\": \"This MR has already been merged and deployed. Test the changes and report any issues found.\"
+      }"
+```
+
+**Setup**
+
+1. Add `QA_TECH_API_TOKEN`, `QATECH_APP_SHORT_ID`, and `STAGING_URL` as **CI/CD → Variables** (mark the token **Protected** and **Masked**).
+2. Set `QATECH_APP_SHORT_ID` to your application's short ID (found in **Settings → Applications**, e.g. `app_gXeBl2`).
+3. Set `STAGING_URL` to your staging/production URL.
+4. Make sure the `change-review` job runs after your deploy job completes (`needs: [deploy]`).
+5. Connect the repository in **Settings → Integrations → GitLab** so the agent can read the MR and post the review note.
+
+**Notes**
+
+- GitLab's default merge commit message ends with `See merge request namespace/project!123`. The script extracts the last `!<number>` token, so it assumes the MR reference is at the end of the message.
+- If you use squash merges with a custom template, include `%{reference}` in the template so the MR reference is present in the commit message.
+- We extract the MR number from the commit message because `CI_MERGE_REQUEST_IID` is only set in merge request pipelines, not on push-to-`main`.
+- Direct pushes to `main` without an MR are skipped automatically.
+- Results are posted back on the merged MR as a note, since the MR is already merged.
+
+<Note>
+  No MR reference in your commits? Use `mode: "rawChanges"` instead and pass a
+  `changes` object with `changeDescription` and a git `diff` computed in CI. See
+  the [Chat API](/api-reference/chat#start-change-review).
+</Note>
+
 ## API tips
 
 For shared API concepts and platform-agnostic workflows, see [CI/CD Integration](/configuration/ci-cd-integration) and [Start Run API](/api-reference/start-run). The examples below focus on GitLab-specific usage.

--- a/configuration/gitlab.mdx
+++ b/configuration/gitlab.mdx
@@ -94,6 +94,38 @@ Example:
 
 If your deployment process is custom, have CI post an MR comment that mentions `@qa.tech` and includes the preview URL. This gives you a consistent trigger pattern without requiring developers to comment manually each time.
 
+### Option D: API trigger (no `@qa.tech` comment)
+
+Trigger the same MR review directly from CI by calling the [Start change review chat API](/api-reference/chat/start-change-review-chat) with `mode: "pr"`. This runs the same review agent as Options A, B, and C and posts the same native MR review note, but you control exactly when it fires and which environment it targets, with no `@qa.tech` comment required.
+
+```yaml
+qatech_mr_review:
+  stage: test
+  only:
+    - merge_requests
+  script: |
+    MR_URL="${CI_MERGE_REQUEST_PROJECT_URL}/-/merge_requests/${CI_MERGE_REQUEST_IID}"
+    curl -sSf -X POST "https://api.qa.tech/v1/chat/change-review" \
+      -H "Authorization: Bearer ${QA_TECH_API_TOKEN}" \
+      -H "Content-Type: application/json" \
+      -d "{
+        \"mode\": \"pr\",
+        \"prUrl\": \"${MR_URL}\",
+        \"vcsProviderId\": \"gitlab\",
+        \"applicationOverrides\": [{
+          \"applicationShortId\": \"${QATECH_APP_SHORT_ID}\",
+          \"environment\": { \"url\": \"${PREVIEW_URL}\" }
+        }]
+      }"
+```
+
+This requires the repository to be connected in **Settings → Integrations → GitLab** so the agent can read the MR and post the review note. The review runs asynchronously; poll [Get chat conversation](/api-reference/chat/get-chat-conversation) if you want CI to wait for the verdict. See [Start change review chat API](/api-reference/chat/start-change-review-chat) for the full request schema.
+
+<Note>
+  Use this same API for **post-merge** reviews when you do not have per-MR
+  preview environments. See [Post-merge change reviews](#post-merge-change-reviews-no-preview-environments).
+</Note>
+
 ## GitLab MR review troubleshooting
 
 **No review starts after MR open**

--- a/core-concepts/ai-agent-testing.mdx
+++ b/core-concepts/ai-agent-testing.mdx
@@ -1,7 +1,7 @@
 ---
-title: QA.tech AI Agents
+title: AI Agents
 description: 'Autonomous AI testing'
-icon: home
+icon: robot
 ---
 
 QA.tech uses specialized AI agents to test your application like humans would, but faster and more thoroughly. Our system automatically routes testing tasks to the right agent based on context-no manual configuration needed.


### PR DESCRIPTION
- Add post-merge change review docs for GitHub Actions and GitLab (extract PR/MR number from merge commit, review against staging/prod)
- Document GitLab Option D: trigger MR reviews from CI via the API without an \`@qa.tech\` comment
- Show AI Agents in the sidebar with a robot icon (rename title, swap `home`→`robot`)

## Testing
- Run the docs site locally (`mintlify dev`) and confirm all three pages render
- Verify the new YAML/code blocks are syntactically valid and copy-paste cleanly
- Check internal anchor links resolve (e.g. `#post-merge-change-reviews-no-preview-environments`)
- Confirm the AI Agents sidebar entry shows the robot icon and "AI Agents" title