### PR TITLE
docs: surface GitLab connection prerequisite before the MR review CI snippet

### DIFF
--- a/configuration/gitlab.mdx
+++ b/configuration/gitlab.mdx
@@ -98,6 +98,8 @@ If your deployment process is custom, have CI post an MR comment that mentions `
 
 Trigger the same MR review directly from CI by calling the [Start change review chat API](/api-reference/chat/start-change-review-chat) with `mode: "pr"`. This runs the same review agent as Options A, B, and C and posts the same native MR review note, but you control exactly when it fires and which environment it targets, with no `@qa.tech` comment required.
 
+This requires the repository to be connected in **Settings → Integrations → GitLab** so the agent can read the MR and post the review note.
+
 ```yaml
 qatech_mr_review:
   stage: test
@@ -119,7 +121,7 @@ qatech_mr_review:
       }"
 ```
 
-This requires the repository to be connected in **Settings → Integrations → GitLab** so the agent can read the MR and post the review note. The review runs asynchronously; poll [Get chat conversation](/api-reference/chat/get-chat-conversation) if you want CI to wait for the verdict. See [Start change review chat API](/api-reference/chat/start-change-review-chat) for the full request schema.
+The review runs asynchronously; poll [Get chat conversation](/api-reference/chat/get-chat-conversation) if you want CI to wait for the verdict. See [Start change review chat API](/api-reference/chat/start-change-review-chat) for the full request schema.
 
 <Note>
   Use this same API for **post-merge** reviews when you do not have per-MR


### PR DESCRIPTION
- Move the "connect repo in Settings → Integrations → GitLab" note above the CI snippet in `configuration/gitlab.mdx` so readers set up the connection before copying the example.

## Testing
- Open `configuration/gitlab.mdx` and confirm the prerequisite note renders before the `qatech_mr_review` YAML block.
- Run the docs preview and verify no broken layout/links around the moved paragraph.